### PR TITLE
fix #62

### DIFF
--- a/packages/gatsby-ucla-site/src/components/states/JurisdictionStatList.js
+++ b/packages/gatsby-ucla-site/src/components/states/JurisdictionStatList.js
@@ -1,5 +1,7 @@
 import React from "react"
 import clsx from "clsx"
+import { format as d3Format } from "d3-format"
+
 import { Typography, withStyles } from "@material-ui/core"
 import { getLang } from "../../common/utils/i18n"
 import { JURISDICTIONS, METRICS } from "../../common/constants"
@@ -58,6 +60,8 @@ const JurisdictionStatList = ({
     // key 0 has count, key 1 has avg
     return isRate ? groupData[key][0] : groupData[key][1]
   }
+
+  const isRateSelected = metric.split("_").pop() === "rate"
   return (
     <Stack className={clsx(classes.root, className)} spacing={2}>
       {JURISDICTIONS.map((jurisdiction) => (
@@ -74,14 +78,16 @@ const JurisdictionStatList = ({
           <NumberStat
             className={classes.stat}
             value={getGroupData(jurisdiction, baseMetric)}
+            isSelectedMetric={!isRateSelected}
             label={getLang(baseMetric, "label")}
           ></NumberStat>
           {groupHasRates(group) && (
             <NumberStat
               className={classes.stat}
-              value={getGroupData(jurisdiction, baseMetric + "_rate", true)}
+              value={getGroupData(jurisdiction, baseMetric, true)}
               label={getLang(baseMetric, "rate")}
-              format=".1%"
+              isSelectedMetric={isRateSelected}
+              format={(n) => d3Format(".1%")(n / 100)} // d3Format expects decimal
             ></NumberStat>
           )}
         </Stack>

--- a/packages/gatsby-ucla-site/src/components/stats/NumberStat.js
+++ b/packages/gatsby-ucla-site/src/components/stats/NumberStat.js
@@ -12,7 +12,10 @@ export const styles = (theme) => ({
   root: {},
   number: {
     fontSize: theme.typography.pxToRem(32),
-    color: theme.palette.secondary.main,
+    color: theme.palette.secondary.secondary,
+    "&.selected": {
+      color: theme.palette.secondary.main,
+    },
     fontWeight: 700,
     lineHeight: 1,
   },
@@ -36,6 +39,7 @@ const NumberStat = ({
   value,
   label,
   format = ",d",
+  isSelectedMetric,
   children,
   ...props
 }) => {
@@ -51,7 +55,12 @@ const NumberStat = ({
       )}
       {...props}
     >
-      <Typography className={classes.number} variant="number">
+      <Typography
+        className={clsx(classes.number, {
+          selected: isSelectedMetric,
+        })}
+        variant="number"
+      >
         {isValid ? formatter(value) : getLang("unavailable")}
       </Typography>
       <Typography className={classes.label} variant="body2">
@@ -67,6 +76,7 @@ NumberStat.propTypes = {
   className: PropTypes.string,
   value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   label: PropTypes.string,
+  isSelectedMetric: PropTypes.bool,
 }
 
 export default withStyles(styles)(NumberStat)


### PR DESCRIPTION
notes: 
- there are still many missing rates (expected?)
- rate values were not in decimal format (5% represented as 5, not .05) so I divided by 100 (d3Format expects decimal)
- some small rates show up as 0.0% (eg CA Death rate)
   - for small enough rates we could decide to show "< 0.1%" (or an additional decimal)

@james-minton feel free to open another issue for follow-up if something looks amiss 
