### PR TITLE
Feature/federal page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ tmp
 .DS_Store
 __MACOSX
 dist
+.vscode

--- a/packages/gatsby-ucla-site/config/metadata.json
+++ b/packages/gatsby-ucla-site/config/metadata.json
@@ -156,7 +156,8 @@
           "link": "/states/wisconsin",
           "type": "internal"
         },
-        { "name": "Wyoming", "link": "/states/wyoming", "type": "internal" }
+        { "name": "Wyoming", "link": "/states/wyoming", "type": "internal" },
+        { "name": "United States", "link": "/federal", "type": "internal" }
       ]
     },
     {

--- a/packages/gatsby-ucla-site/gatsby-node.js
+++ b/packages/gatsby-ucla-site/gatsby-node.js
@@ -59,6 +59,7 @@ exports.sourceNodes = async (params) => {
 }
 
 const StateTemplate = require.resolve(`./src/components/states/states.js`)
+const FederalPage = require.resolve(`./src/components/states/Federal.js`)
 
 exports.createPages = async ({ graphql, actions }) => {
   const { createPage } = actions
@@ -97,5 +98,15 @@ exports.createPages = async ({ graphql, actions }) => {
         `invalid state name: not creating a state page for ${pageName} `
       )
     }
+  })
+
+  createPage({
+    path: `/federal/`,
+    component: FederalPage,
+    context: {
+      // TODO: delete
+      slug: "fed",
+      state: "feda",
+    },
   })
 }

--- a/packages/gatsby-ucla-site/scripts/fetchData.js
+++ b/packages/gatsby-ucla-site/scripts/fetchData.js
@@ -73,6 +73,7 @@ const filingsOrdersMap = {
   state: ["State or Territory", "string", roughMatch],
   court: ["Federal Court Name", "string", selectCourtName],
   granted: ["Release Granted", "string", roughMatch],
+  incarcerationType: ["Type of Incarceration", "string", roughMatch],
 }
 
 const filingsOrdersParser = (row) => parseMap(row, filingsOrdersMap)
@@ -83,6 +84,7 @@ exports.getFilingsOrders = () =>
     const lines = d.substring(dataIndex)
     const rows = csvParse(lines, filingsOrdersParser)
     const byState = groups(rows, (d) => d.state)
+
     const result = byState.map((stateGroup) => {
       const stateData = stateGroup[1]
       const facilityCount = groups(stateData, (d) => d.facility).length
@@ -96,6 +98,20 @@ exports.getFilingsOrders = () =>
           .length,
       }
     })
+
+    const federalTypeRows = rows.filter((d) => d.incarcerationType.toLowerCase() === "federal prison")
+    const federalFacilityCount = groups(federalTypeRows, (d) => d.facility).length
+    const federalCourtCount = groups(federalTypeRows, (d) => d.court).length
+    const federalData = {
+      state: 'federal',
+      total: federalTypeRows.length,
+      facilityCount: federalFacilityCount,
+      courtCount: federalCourtCount,
+      granted: federalTypeRows.filter((d) => d.granted.toLowerCase() === "yes")
+        .length,
+    }
+    result.push(federalData)  
+
     return result
   })
 

--- a/packages/gatsby-ucla-site/scripts/fetchData.js
+++ b/packages/gatsby-ucla-site/scripts/fetchData.js
@@ -99,18 +99,21 @@ exports.getFilingsOrders = () =>
       }
     })
 
-    const federalTypeRows = rows.filter((d) => d.incarcerationType.toLowerCase() === "federal prison")
-    const federalFacilityCount = groups(federalTypeRows, (d) => d.facility).length
+    const federalTypeRows = rows.filter(
+      (d) => d.incarcerationType.toLowerCase() === "federal prison"
+    )
+    const federalFacilityCount = groups(federalTypeRows, (d) => d.facility)
+      .length
     const federalCourtCount = groups(federalTypeRows, (d) => d.court).length
     const federalData = {
-      state: 'federal',
+      state: "federal",
       total: federalTypeRows.length,
       facilityCount: federalFacilityCount,
       courtCount: federalCourtCount,
       granted: federalTypeRows.filter((d) => d.granted.toLowerCase() === "yes")
         .length,
     }
-    result.push(federalData)  
+    result.push(federalData)
 
     return result
   })

--- a/packages/gatsby-ucla-site/src/common/constants.js
+++ b/packages/gatsby-ucla-site/src/common/constants.js
@@ -9,7 +9,7 @@ export const KEYS = {
   population: "population",
 }
 
-export const GROUPS = ["residents", "staff"]
+export const GROUPS = ["residents", "staff", "residentsFederal"]
 
 export const JURISDICTIONS = ["state", "federal", "county"]
 
@@ -23,6 +23,7 @@ export const METRICS = {
     "active_rate",
   ],
   staff: ["confirmed", "deaths", "active"],
+  residentsFederal: ["confirmed", "deaths", "active"],
 }
 
 export const METRIC_FORMATTERS = {

--- a/packages/gatsby-ucla-site/src/common/constants.js
+++ b/packages/gatsby-ucla-site/src/common/constants.js
@@ -9,7 +9,7 @@ export const KEYS = {
   population: "population",
 }
 
-export const GROUPS = ["residents", "staff", "residentsFederal"]
+export const GROUPS = ["residents", "staff"]
 
 export const JURISDICTIONS = ["state", "federal", "county"]
 
@@ -23,15 +23,6 @@ export const METRICS = {
     "active_rate",
   ],
   staff: ["confirmed", "deaths", "active"],
-  residentsFederal: [
-    // TODO: revert
-    "confirmed",
-    "deaths",
-    "active",
-    "confirmed_rate",
-    "deaths_rate",
-    "active_rate",
-  ],
 }
 
 export const METRIC_FORMATTERS = {

--- a/packages/gatsby-ucla-site/src/common/constants.js
+++ b/packages/gatsby-ucla-site/src/common/constants.js
@@ -23,7 +23,15 @@ export const METRICS = {
     "active_rate",
   ],
   staff: ["confirmed", "deaths", "active"],
-  residentsFederal: ["confirmed", "deaths", "active"],
+  residentsFederal: [
+    // TODO: revert
+    "confirmed",
+    "deaths",
+    "active",
+    "confirmed_rate",
+    "deaths_rate",
+    "active_rate",
+  ],
 }
 
 export const METRIC_FORMATTERS = {

--- a/packages/gatsby-ucla-site/src/components/home/HomeMap.js
+++ b/packages/gatsby-ucla-site/src/components/home/HomeMap.js
@@ -90,11 +90,7 @@ const HomeMap = ({ classes, title, description, className, ...props }) => {
     setSelected(geo)
     navigate(`states/${getSlug(geo.properties.name)}`)
   }
-  const goFederal = () => {
-    // TODO
-    setSelected("fed")
-    navigate(`federal`)
-  }
+
   return (
     <Block
       type="fullWidth"
@@ -102,7 +98,6 @@ const HomeMap = ({ classes, title, description, className, ...props }) => {
       className={clsx(classes.root, className)}
       {...props}
     >
-      <div onClick={goFederal}>Federal Page</div>
       <ResponsiveContainer className={classes.controls}>
         <Grid container spacing={1}>
           <Grid item xs={12} md={8}>

--- a/packages/gatsby-ucla-site/src/components/home/HomeMap.js
+++ b/packages/gatsby-ucla-site/src/components/home/HomeMap.js
@@ -90,6 +90,11 @@ const HomeMap = ({ classes, title, description, className, ...props }) => {
     setSelected(geo)
     navigate(`states/${getSlug(geo.properties.name)}`)
   }
+  const goFederal = () => {
+    // TODO
+    setSelected("fed")
+    navigate(`federal`)
+  }
   return (
     <Block
       type="fullWidth"
@@ -97,6 +102,7 @@ const HomeMap = ({ classes, title, description, className, ...props }) => {
       className={clsx(classes.root, className)}
       {...props}
     >
+      <div onClick={goFederal}>Federal Page</div>
       <ResponsiveContainer className={classes.controls}>
         <Grid container spacing={1}>
           <Grid item xs={12} md={8}>

--- a/packages/gatsby-ucla-site/src/components/states/FacilitiesTable.js
+++ b/packages/gatsby-ucla-site/src/components/states/FacilitiesTable.js
@@ -30,6 +30,7 @@ const FacilitiesTable = ({
   classes,
   group = "residents",
   metric,
+  isFederal,
   ...props
 }) => {
   const columns = React.useMemo(
@@ -44,9 +45,11 @@ const FacilitiesTable = ({
               <Typography className={classes.name} variant="body1">
                 {prop.value}
               </Typography>
-              <Typography variant="body2" color="textSecondary">
-                {getLang(prop.row.original.jurisdiction)}
-              </Typography>
+              {!isFederal && (
+                <Typography variant="body2" color="textSecondary">
+                  {getLang(prop.row.original.jurisdiction)}
+                </Typography>
+              )}
             </>
           )
         },

--- a/packages/gatsby-ucla-site/src/components/states/Federal.js
+++ b/packages/gatsby-ucla-site/src/components/states/Federal.js
@@ -50,7 +50,7 @@ const useStyles = makeStyles((theme) => ({
   step: {
     display: "flex",
     minHeight: `calc(100vh - ${theme.layout.headerHeight})`,
-    // justifyContent: "center",
+    justifyContent: "center",
     padding: theme.spacing(3, 0),
   },
   first: {

--- a/packages/gatsby-ucla-site/src/components/states/Federal.js
+++ b/packages/gatsby-ucla-site/src/components/states/Federal.js
@@ -1,0 +1,337 @@
+import React from "react"
+import clsx from "clsx"
+import { graphql, navigate } from "gatsby"
+import { Layout } from "gatsby-theme-hyperobjekt-core"
+import { makeStyles, Typography } from "@material-ui/core"
+
+import { Step, Scrollama } from "@hyperobjekt/react-scrollama"
+import {
+  ResidentsSummary,
+  Facilities,
+  Filings,
+  Grassroots,
+  Immigration,
+  Releases,
+  StaffSummary,
+} from "./sections"
+import useStatesStore from "./useStatesStore"
+import Visual from "./Visual"
+import shallow from "zustand/shallow"
+import SectionNavigation from "../SectionNavigation"
+import ResponsiveContainer from "../ResponsiveContainer"
+
+const useStyles = makeStyles((theme) => ({
+  block: {
+    padding: theme.spacing(0, 2),
+    alignItems: "flex-start",
+    [theme.breakpoints.up("sm")]: {
+      padding: theme.spacing(0, 3),
+    },
+  },
+  visual: {
+    position: "sticky",
+    top: `calc(${theme.layout.headerHeight} + 56px)`,
+    width: `calc(100% - 26.25rem)`,
+    // full vertical height, minus header
+    height: `calc(100vh - ${theme.layout.headerHeight} - 56px)`,
+    marginLeft: "auto",
+    display: "flex",
+    justifyContent: "center",
+    alignItems: "stretch",
+    // make some space for the legend
+    "& .rsm-svg": {
+      flex: 1,
+      maxHeight: `calc(100% - 5rem)`,
+    },
+  },
+  title: {
+    marginTop: theme.spacing(5),
+  },
+  step: {
+    display: "flex",
+    minHeight: `calc(100vh - ${theme.layout.headerHeight})`,
+    justifyContent: "center",
+    padding: theme.spacing(3, 0),
+  },
+  first: {
+    minHeight: `calc(100vh - ${theme.layout.headerHeight} - ${theme.spacing(
+      10
+    )})`,
+  },
+  content: {
+    marginTop: `calc(-100vh + ${theme.layout.headerHeight} + 56px)`,
+    position: "relative",
+    maxWidth: "26.25rem",
+  },
+}))
+
+const content = {
+  mapDescription: "Spikes represents the ${metric} in a facility for ${group}",
+  sections: [
+    {
+      id: "residents",
+      lang: {
+        title: "Statewide ${metric} among incarcerated people",
+        link: "Incarcerated People",
+        notes: {
+          confirmed:
+            "Testing practices vary widely by correctional agency. True case counts are likely higher and may be significantly higher than reported.",
+          confirmed_rate:
+            "Rates are calculated using a denominator of facility-level population as of February 2020. See our methodology to learn more about why we chose this approach.",
+          active:
+            "Testing practices vary widely by correctional agency. True case counts are likely higher and may be significantly higher than reported.",
+          active_rate:
+            "Rates are calculated using a denominator of facility-level population as of February 2020. See our methodology to learn more about why we chose this approach.",
+          deaths:
+            "Testing practices vary widely by correctional agency. True mortality counts are likely higher and may be significantly higher than reported. Agencies also differ in the categories of deaths they report as COVID-19-related.",
+          deaths_rate:
+            "Rates are calculated using a denominator of facility-level population as of February 2020. See our methodology to learn more about why we chose this approach. ",
+          tests:
+            "Some agencies report the number of persons tested, while others report the number of tests administered. We record whichever number is available.",
+          tests_rate:
+            "Rates are calculated using a denominator of facility-level population as of February 2020. See our methodology to learn more about why we chose this approach.",
+        },
+      },
+    },
+    {
+      id: "staff",
+      lang: {
+        title: "Statewide ${metric} among staff",
+        link: "Staff",
+        unavailable: "${metric} is not available for staff.",
+        notes: {
+          active:
+            "Not all agencies report data on staff COVID-19 cases. Some jurisdictions leave it to staff members’ discretion whether to report positive test results they receive from community healthcare providers. As a result, the number of staff cases reported may be lower even than the number detected by testing.",
+          active_rate:
+            "We do not have reliable data for staffing levels at all facilities. As a result, we are not currently providing rates for staff.",
+          confirmed:
+            "Not all agencies report data on staff COVID-19 cases. Some jurisdictions leave it to staff members’ discretion whether to report positive test results they receive from community healthcare providers.",
+          confirmed_rate:
+            "We do not have reliable data for staffing levels at all facilities. As a result, we are not currently providing rates for staff.",
+          deaths:
+            "Not all correctional agencies report data on staff deaths related to COVID-19. True COVID-19-related mortality counts are likely higher and may be significantly higher than reported.",
+          deaths_rate:
+            "We do not have reliable data for staffing levels at all facilities. As a result, we are not currently providing rates for staff.",
+          tests:
+            "Testing data is not reported by all correctional agencies. Some jurisdictions leave it to staff members’ discretion whether to report positive test results they receive from community healthcare providers. True test counts are likely higher and may be significantly higher than reported.",
+          tests_rate:
+            "We do not have reliable data for staffing levels at all facilities. As a result, we are not currently providing rates for staff.",
+        },
+      },
+    },
+    {
+      id: "facilities",
+      lang: {
+        title: "Facilities by ${metric}",
+        link: "Facilities",
+        body: "",
+      },
+    },
+    {
+      id: "filings",
+      lang: {
+        title: "Legal Filings and Court Orders Related to COVID-19",
+        link: "Filings & Court Orders",
+        body:
+          "Our project collaborates with Bronx Defenders, Columbia Law School’s Center for Institutional and Social Change, and Zealous to collect legal documents from around the country related to COVID-19 and incarceration. Together, we then organize and code them into the jointly managed <a href='https://healthisjustice.org/litigation-hub/login' rel='noreferrer' target='_blank'>Health is Justice litigation hub</a> for public defenders, litigators, and other advocates. The majority of the legal documents in the Health is Justice litigation hub are federal court opinions, but we are expanding to state legal filings, declarations, and exhibits.<br /><br />In addition to the Health is Justice litigation hub, our project also manages additional data self-reported by advocates regarding COVID-19-related legal filings involving <a href='https://docs.google.com/spreadsheets/d/1X6uJkXXS-O6eePLxw2e4JeRtM41uPZ2eRcOA_HkPVTk/edit#gid=1832796231' rel='noreferrer' target='_blank'>incarcerated youth</a> and <a href='https://docs.google.com/spreadsheets/d/1X6uJkXXS-O6eePLxw2e4JeRtM41uPZ2eRcOA_HkPVTk/edit#gid=22612814' rel='noreferrer' target='_blank'>individuals in immigration detention</a>.",
+        visual: {
+          courtCount: "number of courts",
+          granted: "compassionate releases granted",
+          facilityCount: "number of facilities",
+          total: "filings coded by our team",
+          unavailable: "No filings data available.",
+        },
+      },
+    },
+    {
+      id: "releases",
+      lang: {
+        title: "Prison and Jail Releases Related to COVID-19",
+        link: "Releases",
+        body:
+          "We collect data on jurisdictions across the U.S. that have released people from adult prison and jail custody in response to the COVID-19 pandemic. For the most part, we only include release efforts where the data source includes some sort of programmatic description of who is being released (e.g., people with technical violations of parole, people charged with non-violent crimes, etc.). See our <a href='https://docs.google.com/spreadsheets/d/1X6uJkXXS-O6eePLxw2e4JeRtM41uPZ2eRcOA_HkPVTk/edit#gid=845601985' rel='noreferrer' target='_blank'>full prison releases dataset</a> here and <a href='https://docs.google.com/spreadsheets/d/1X6uJkXXS-O6eePLxw2e4JeRtM41uPZ2eRcOA_HkPVTk/edit#gid=1678228533' rel='noreferrer' target='_blank'>jail releases dataset</a> for more.",
+        visual: {
+          prisonCount: "prison release efforts",
+          jailCount: "jail release efforts",
+        },
+      },
+    },
+    {
+      id: "immigration",
+      lang: {
+        title: "COVID-19 Cases and Deaths in Immigration Detention",
+        link: "Immigration",
+        body:
+          "We collect data on COVID-19 infections and deaths of detainees and staff within all 120 U.S. Immigration and Customs Enforcement (ICE) facilities, as well as other facilities detaining people under ICE jurisdiction, across the United States. Our data come directly from ICE’s website and are updated almost every day. As of November 23, 2020, ICE no longer reports COVID-19-related cases and deaths among staff. View our <a href='https://docs.google.com/spreadsheets/d/1X6uJkXXS-O6eePLxw2e4JeRtM41uPZ2eRcOA_HkPVTk/edit#gid=278828877' rel='noreferrer' target='_blank'>full immigration dateset</a>.",
+        visual: {
+          facilityCount: "ICE facilities",
+          caseCount: "detainee cases",
+          deathsCount: "detainee deaths",
+        },
+      },
+    },
+    {
+      id: "grassroots",
+      lang: {
+        title:
+          "Grassroots and Community Organizing Efforts Related to COVID-19",
+        link: "Grassroots & Organizing",
+        body:
+          "Our team collects data on grassroots and community organizing efforts by incarcerated people, their families, community-based organizations, nonprofits, and advocates aimed at influencing government agencies to protect the lives of people incarcerated in prisons, jails, and detention centers against the threats posed by COVID-19. <a href='https://docs.google.com/spreadsheets/d/1X6uJkXXS-O6eePLxw2e4JeRtM41uPZ2eRcOA_HkPVTk/edit#gid=1720501154' rel='noreferrer' target='_blank'>View our full grassroots and organizing dataset</a>. ",
+        visual: {
+          effortCount: "efforts",
+          internalCount: "efforts happening behind bars",
+          externalCount: "efforts started externally",
+          coordinatedCount: "coordinated efforts (inside and outside)",
+        },
+      },
+    },
+  ],
+}
+
+const SECTION_COMPONENTS = {
+  residents: ResidentsSummary,
+  // staff: StaffSummary,
+  // facilities: Facilities,
+  // filings: Filings,
+  // releases: Releases,
+  // immigration: Immigration,
+  // grassroots: Grassroots,
+}
+
+const StateTemplate = ({ pageContext, data }) => {
+  console.log("GERANOME: ", data)
+  // return <div>HI THERE</div>
+
+  // classes used on this page
+  const classes = useStyles()
+  // pull state name from page context
+  // const { state } = pageContext
+  const state = "federal"
+  // track current step index for scrollytelling
+  const [
+    currentStep,
+    setCurrentStep,
+    setStateName,
+    setData,
+    setContent,
+  ] = useStatesStore(
+    (state) => [
+      state.currentStep,
+      state.setCurrentStep,
+      state.setStateName,
+      state.setData,
+      state.setContent,
+    ],
+    shallow
+  )
+  // set the state name in the store
+  setStateName(state)
+  // set the data in the store
+  setData(data)
+  // set the content for the page
+  setContent(content)
+
+  // update current step when entering
+  const handleStepEnter = ({ data }) => {
+    setCurrentStep(data)
+  }
+
+  const handleNavigation = (section) => {
+    console.log("seciton", section)
+    navigate("#" + section)
+    setCurrentStep(section)
+  }
+
+  // setctions for section nav
+  const sections = content.sections.map((s) => ({
+    id: s.id,
+    name: s.lang.link,
+  }))
+
+  return (
+    <Layout title={state}>
+      <SectionNavigation
+        current={currentStep}
+        sections={sections}
+        onSelect={handleNavigation}
+      />
+      <ResponsiveContainer>
+        {/* <Visual className={classes.visual} /> */}
+        <div className={classes.content}>
+          <Scrollama onStepEnter={handleStepEnter}>
+            {content.sections.map((section, index) => {
+              const Component = SECTION_COMPONENTS[section.id]
+              return (
+                <Step key={section.id} data={section.id}>
+                  <div id={section.id}>
+                    {index === 0 && (
+                      <Typography variant="h2" className={classes.title}>
+                        {state}
+                      </Typography>
+                    )}
+                    <ResidentsSummary
+                      isFederal={true}
+                      className={clsx(classes.step, {
+                        [classes.first]: index === 0,
+                      })}
+                      data={data}
+                      {...section}
+                    />
+                  </div>
+                </Step>
+              )
+            })}
+          </Scrollama>
+        </div>
+      </ResponsiveContainer>
+    </Layout>
+  )
+}
+
+StateTemplate.propTypes = {}
+
+export const query = graphql`
+  query {
+    allFacilities(filter: { jurisdiction: { eq: "federal" } }) {
+      edges {
+        node {
+          city
+          coords
+          id
+          jurisdiction
+          name
+          residents {
+            active
+            active_rate
+            confirmed
+            confirmed_rate
+            deaths
+            deaths_rate
+          }
+          staff {
+            active
+            confirmed
+            deaths
+            recovered
+          }
+          state
+        }
+      }
+    }
+    allPrisonReleases(filter: { state: { eq: "Federal BOP" } }) {
+      edges {
+        node {
+          id
+          releases
+          facility
+          source
+          state
+          capacity
+        }
+      }
+    }
+  }
+`
+
+export default StateTemplate

--- a/packages/gatsby-ucla-site/src/components/states/Federal.js
+++ b/packages/gatsby-ucla-site/src/components/states/Federal.js
@@ -71,19 +71,46 @@ const content = {
     {
       id: "residents",
       lang: {
-        title: "Statewide ${metric} among incarcerated people",
+        title: "Nationwide ${metric} among incarcerated people",
         link: "Incarcerated People",
         notes: {
+          // TODO: prune
           confirmed:
-            "Testing practices vary widely by correctional agency. True case counts are likely higher and may be significantly higher than reported.",
+            "True case counts are likely higher and may be significantly higher than reported.",
           confirmed_rate:
             "Rates are calculated using a denominator of facility-level population as of February 2020. See our methodology to learn more about why we chose this approach.",
           active:
-            "Testing practices vary widely by correctional agency. True case counts are likely higher and may be significantly higher than reported.",
+            "True case counts are likely higher and may be significantly higher than reported.",
           active_rate:
             "Rates are calculated using a denominator of facility-level population as of February 2020. See our methodology to learn more about why we chose this approach.",
           deaths:
-            "Testing practices vary widely by correctional agency. True mortality counts are likely higher and may be significantly higher than reported. Agencies also differ in the categories of deaths they report as COVID-19-related.",
+            "True mortality counts are likely higher and may be significantly higher than reported.",
+          deaths_rate:
+            "Rates are calculated using a denominator of facility-level population as of February 2020. See our methodology to learn more about why we chose this approach. ",
+          tests:
+            "Some agencies report the number of persons tested, while others report the number of tests administered. We record whichever number is available.",
+          tests_rate:
+            "Rates are calculated using a denominator of facility-level population as of February 2020. See our methodology to learn more about why we chose this approach.",
+        },
+      },
+    },
+    {
+      id: "residents",
+      lang: {
+        title: "Nationwide ${metric} among incarcerated people",
+        link: "Incarcerated People",
+        notes: {
+          // TODO: prune
+          confirmed:
+            "True case counts are likely higher and may be significantly higher than reported.",
+          confirmed_rate:
+            "Rates are calculated using a denominator of facility-level population as of February 2020. See our methodology to learn more about why we chose this approach.",
+          active:
+            "True case counts are likely higher and may be significantly higher than reported.",
+          active_rate:
+            "Rates are calculated using a denominator of facility-level population as of February 2020. See our methodology to learn more about why we chose this approach.",
+          deaths:
+            "True mortality counts are likely higher and may be significantly higher than reported.",
           deaths_rate:
             "Rates are calculated using a denominator of facility-level population as of February 2020. See our methodology to learn more about why we chose this approach. ",
           tests:
@@ -96,24 +123,24 @@ const content = {
     {
       id: "staff",
       lang: {
-        title: "Statewide ${metric} among staff",
+        title: "Nationwide ${metric} among staff",
         link: "Staff",
         unavailable: "${metric} is not available for staff.",
         notes: {
           active:
-            "Not all agencies report data on staff COVID-19 cases. Some jurisdictions leave it to staff members’ discretion whether to report positive test results they receive from community healthcare providers. As a result, the number of staff cases reported may be lower even than the number detected by testing.",
+            "True case counts are likely higher and may be significantly higher than reported",
           active_rate:
             "We do not have reliable data for staffing levels at all facilities. As a result, we are not currently providing rates for staff.",
           confirmed:
-            "Not all agencies report data on staff COVID-19 cases. Some jurisdictions leave it to staff members’ discretion whether to report positive test results they receive from community healthcare providers.",
+            "True case counts are likely higher and may be significantly higher than reported",
           confirmed_rate:
             "We do not have reliable data for staffing levels at all facilities. As a result, we are not currently providing rates for staff.",
           deaths:
-            "Not all correctional agencies report data on staff deaths related to COVID-19. True COVID-19-related mortality counts are likely higher and may be significantly higher than reported.",
+            "True case counts are likely higher and may be significantly higher than reported",
           deaths_rate:
             "We do not have reliable data for staffing levels at all facilities. As a result, we are not currently providing rates for staff.",
           tests:
-            "Testing data is not reported by all correctional agencies. Some jurisdictions leave it to staff members’ discretion whether to report positive test results they receive from community healthcare providers. True test counts are likely higher and may be significantly higher than reported.",
+            "",
           tests_rate:
             "We do not have reliable data for staffing levels at all facilities. As a result, we are not currently providing rates for staff.",
         },
@@ -127,82 +154,78 @@ const content = {
         body: "",
       },
     },
-    {
-      id: "filings",
-      lang: {
-        title: "Legal Filings and Court Orders Related to COVID-19",
-        link: "Filings & Court Orders",
-        body:
-          "Our project collaborates with Bronx Defenders, Columbia Law School’s Center for Institutional and Social Change, and Zealous to collect legal documents from around the country related to COVID-19 and incarceration. Together, we then organize and code them into the jointly managed <a href='https://healthisjustice.org/litigation-hub/login' rel='noreferrer' target='_blank'>Health is Justice litigation hub</a> for public defenders, litigators, and other advocates. The majority of the legal documents in the Health is Justice litigation hub are federal court opinions, but we are expanding to state legal filings, declarations, and exhibits.<br /><br />In addition to the Health is Justice litigation hub, our project also manages additional data self-reported by advocates regarding COVID-19-related legal filings involving <a href='https://docs.google.com/spreadsheets/d/1X6uJkXXS-O6eePLxw2e4JeRtM41uPZ2eRcOA_HkPVTk/edit#gid=1832796231' rel='noreferrer' target='_blank'>incarcerated youth</a> and <a href='https://docs.google.com/spreadsheets/d/1X6uJkXXS-O6eePLxw2e4JeRtM41uPZ2eRcOA_HkPVTk/edit#gid=22612814' rel='noreferrer' target='_blank'>individuals in immigration detention</a>.",
-        visual: {
-          courtCount: "number of courts",
-          granted: "compassionate releases granted",
-          facilityCount: "number of facilities",
-          total: "filings coded by our team",
-          unavailable: "No filings data available.",
-        },
-      },
-    },
+    // {
+    //   id: "filings",
+    //   lang: {
+    //     title: "Legal Filings and Court Orders Related to COVID-19",
+    //     link: "Filings & Court Orders",
+    //     body:
+    //       "Our project collaborates with Bronx Defenders, Columbia Law School’s Center for Institutional and Social Change, and Zealous to collect legal documents from around the country related to COVID-19 and incarceration. Together, we then organize and code them into the jointly managed <a href='https://healthisjustice.org/litigation-hub/login' rel='noreferrer' target='_blank'>Health is Justice litigation hub</a> for public defenders, litigators, and other advocates. The majority of the legal documents in the Health is Justice litigation hub are federal court opinions, but we are expanding to state legal filings, declarations, and exhibits.<br /><br />In addition to the Health is Justice litigation hub, our project also manages additional data self-reported by advocates regarding COVID-19-related legal filings involving <a href='https://docs.google.com/spreadsheets/d/1X6uJkXXS-O6eePLxw2e4JeRtM41uPZ2eRcOA_HkPVTk/edit#gid=1832796231' rel='noreferrer' target='_blank'>incarcerated youth</a> and <a href='https://docs.google.com/spreadsheets/d/1X6uJkXXS-O6eePLxw2e4JeRtM41uPZ2eRcOA_HkPVTk/edit#gid=22612814' rel='noreferrer' target='_blank'>individuals in immigration detention</a>.",
+    //     visual: {
+    //       courtCount: "number of courts",
+    //       granted: "compassionate releases granted",
+    //       facilityCount: "number of facilities",
+    //       total: "filings coded by our team",
+    //       unavailable: "No filings data available.",
+    //     },
+    //   },
+    // },
     {
       id: "releases",
       lang: {
-        title: "Prison and Jail Releases Related to COVID-19",
+        title: "Federal Prison Releases Related to COVID-19",
         link: "Releases",
         body:
-          "We collect data on jurisdictions across the U.S. that have released people from adult prison and jail custody in response to the COVID-19 pandemic. For the most part, we only include release efforts where the data source includes some sort of programmatic description of who is being released (e.g., people with technical violations of parole, people charged with non-violent crimes, etc.). See our <a href='https://docs.google.com/spreadsheets/d/1X6uJkXXS-O6eePLxw2e4JeRtM41uPZ2eRcOA_HkPVTk/edit#gid=845601985' rel='noreferrer' target='_blank'>full prison releases dataset</a> here and <a href='https://docs.google.com/spreadsheets/d/1X6uJkXXS-O6eePLxw2e4JeRtM41uPZ2eRcOA_HkPVTk/edit#gid=1678228533' rel='noreferrer' target='_blank'>jail releases dataset</a> for more.",
+          "We collect data on jurisdictions across the U.S. that have released people from adult prison and jail custody in response to the COVID-19 pandemic. For the most part, we only include release efforts where the data source includes some sort of programmatic description of who is being released (e.g., people with technical violations of parole, people charged with non-violent crimes, etc.). See our <a href='https://docs.google.com/spreadsheets/d/1X6uJkXXS-O6eePLxw2e4JeRtM41uPZ2eRcOA_HkPVTk/edit#gid=845601985' rel='noreferrer' target='_blank'>full prison releases dataset</a> for more.",
         visual: {
           prisonCount: "prison release efforts",
-          jailCount: "jail release efforts",
         },
       },
     },
-    {
-      id: "immigration",
-      lang: {
-        title: "COVID-19 Cases and Deaths in Immigration Detention",
-        link: "Immigration",
-        body:
-          "We collect data on COVID-19 infections and deaths of detainees and staff within all 120 U.S. Immigration and Customs Enforcement (ICE) facilities, as well as other facilities detaining people under ICE jurisdiction, across the United States. Our data come directly from ICE’s website and are updated almost every day. As of November 23, 2020, ICE no longer reports COVID-19-related cases and deaths among staff. View our <a href='https://docs.google.com/spreadsheets/d/1X6uJkXXS-O6eePLxw2e4JeRtM41uPZ2eRcOA_HkPVTk/edit#gid=278828877' rel='noreferrer' target='_blank'>full immigration dateset</a>.",
-        visual: {
-          facilityCount: "ICE facilities",
-          caseCount: "detainee cases",
-          deathsCount: "detainee deaths",
-        },
-      },
-    },
-    {
-      id: "grassroots",
-      lang: {
-        title:
-          "Grassroots and Community Organizing Efforts Related to COVID-19",
-        link: "Grassroots & Organizing",
-        body:
-          "Our team collects data on grassroots and community organizing efforts by incarcerated people, their families, community-based organizations, nonprofits, and advocates aimed at influencing government agencies to protect the lives of people incarcerated in prisons, jails, and detention centers against the threats posed by COVID-19. <a href='https://docs.google.com/spreadsheets/d/1X6uJkXXS-O6eePLxw2e4JeRtM41uPZ2eRcOA_HkPVTk/edit#gid=1720501154' rel='noreferrer' target='_blank'>View our full grassroots and organizing dataset</a>. ",
-        visual: {
-          effortCount: "efforts",
-          internalCount: "efforts happening behind bars",
-          externalCount: "efforts started externally",
-          coordinatedCount: "coordinated efforts (inside and outside)",
-        },
-      },
-    },
+    // {
+    //   id: "immigration",
+    //   lang: {
+    //     title: "COVID-19 Cases and Deaths in Immigration Detention",
+    //     link: "Immigration",
+    //     body:
+    //       "We collect data on COVID-19 infections and deaths of detainees and staff within all 120 U.S. Immigration and Customs Enforcement (ICE) facilities, as well as other facilities detaining people under ICE jurisdiction, across the United States. Our data come directly from ICE’s website and are updated almost every day. As of November 23, 2020, ICE no longer reports COVID-19-related cases and deaths among staff. View our <a href='https://docs.google.com/spreadsheets/d/1X6uJkXXS-O6eePLxw2e4JeRtM41uPZ2eRcOA_HkPVTk/edit#gid=278828877' rel='noreferrer' target='_blank'>full immigration dateset</a>.",
+    //     visual: {
+    //       facilityCount: "ICE facilities",
+    //       caseCount: "detainee cases",
+    //       deathsCount: "detainee deaths",
+    //     },
+    //   },
+    // },
+    // {
+    //   id: "grassroots",
+    //   lang: {
+    //     title:
+    //       "Grassroots and Community Organizing Efforts Related to COVID-19",
+    //     link: "Grassroots & Organizing",
+    //     body:
+    //       "Our team collects data on grassroots and community organizing efforts by incarcerated people, their families, community-based organizations, nonprofits, and advocates aimed at influencing government agencies to protect the lives of people incarcerated in prisons, jails, and detention centers against the threats posed by COVID-19. <a href='https://docs.google.com/spreadsheets/d/1X6uJkXXS-O6eePLxw2e4JeRtM41uPZ2eRcOA_HkPVTk/edit#gid=1720501154' rel='noreferrer' target='_blank'>View our full grassroots and organizing dataset</a>. ",
+    //     visual: {
+    //       effortCount: "efforts",
+    //       internalCount: "efforts happening behind bars",
+    //       externalCount: "efforts started externally",
+    //       coordinatedCount: "coordinated efforts (inside and outside)",
+    //     },
+    //   },
+    // },
   ],
 }
 
 const SECTION_COMPONENTS = {
   residents: ResidentsSummary,
-  // staff: StaffSummary,
-  // facilities: Facilities,
-  // filings: Filings,
-  // releases: Releases,
+  staff: StaffSummary,
+  facilities: Facilities,
+  filings: Filings,
+  releases: Releases,
   // immigration: Immigration,
   // grassroots: Grassroots,
 }
 
 const StateTemplate = ({ pageContext, data }) => {
-  console.log("GERANOME: ", data)
-  // return <div>HI THERE</div>
-
   // classes used on this page
   const classes = useStyles()
   // pull state name from page context
@@ -234,6 +257,7 @@ const StateTemplate = ({ pageContext, data }) => {
 
   // update current step when entering
   const handleStepEnter = ({ data }) => {
+    console.log('hse: ', data)
     setCurrentStep(data)
   }
 
@@ -262,15 +286,17 @@ const StateTemplate = ({ pageContext, data }) => {
           <Scrollama onStepEnter={handleStepEnter}>
             {content.sections.map((section, index) => {
               const Component = SECTION_COMPONENTS[section.id]
+              console.log("||", section.id, "||", Component)
               return (
                 <Step key={section.id} data={section.id}>
                   <div id={section.id}>
                     {index === 0 && (
                       <Typography variant="h2" className={classes.title}>
-                        {state}
+                        {state}ihhi
                       </Typography>
                     )}
-                    <ResidentsSummary
+                    <div>{index}!</div>
+                    <Component
                       isFederal={true}
                       className={clsx(classes.step, {
                         [classes.first]: index === 0,

--- a/packages/gatsby-ucla-site/src/components/states/Federal.js
+++ b/packages/gatsby-ucla-site/src/components/states/Federal.js
@@ -28,29 +28,29 @@ const useStyles = makeStyles((theme) => ({
       padding: theme.spacing(0, 3),
     },
   },
-  visual: {
-    position: "sticky",
-    top: `calc(${theme.layout.headerHeight} + 56px)`,
-    width: `calc(100% - 26.25rem)`,
-    // full vertical height, minus header
-    height: `calc(100vh - ${theme.layout.headerHeight} - 56px)`,
-    marginLeft: "auto",
-    display: "flex",
-    justifyContent: "center",
-    alignItems: "stretch",
-    // make some space for the legend
-    "& .rsm-svg": {
-      flex: 1,
-      maxHeight: `calc(100% - 5rem)`,
-    },
-  },
+  // visual: {
+  //   position: "sticky",
+  //   top: `calc(${theme.layout.headerHeight} + 56px)`,
+  //   width: `calc(100% - 26.25rem)`,
+  //   // full vertical height, minus header
+  //   height: `calc(100vh - ${theme.layout.headerHeight} - 56px)`,
+  //   marginLeft: "auto",
+  //   display: "flex",
+  //   justifyContent: "center",
+  //   alignItems: "stretch",
+  //   // make some space for the legend
+  //   "& .rsm-svg": {
+  //     flex: 1,
+  //     maxHeight: `calc(100% - 5rem)`,
+  //   },
+  // },
   title: {
     marginTop: theme.spacing(5),
   },
   step: {
     display: "flex",
     minHeight: `calc(100vh - ${theme.layout.headerHeight})`,
-    justifyContent: "center",
+    // justifyContent: "center",
     padding: theme.spacing(3, 0),
   },
   first: {
@@ -59,41 +59,21 @@ const useStyles = makeStyles((theme) => ({
     )})`,
   },
   content: {
-    marginTop: `calc(-100vh + ${theme.layout.headerHeight} + 56px)`,
     position: "relative",
-    maxWidth: "26.25rem",
+    // DEPARTURES FROM STATES PAGES
+    marginTop: `calc(${theme.layout.headerHeight} + 56px)`,
+    // to center single column
+    maxWidth: "42rem",
+    margin: "auto",
+    "& .embedded-stats": {
+      padding: theme.spacing(1, 2, 3),
+    },
   },
 }))
 
 const content = {
   mapDescription: "Spikes represents the ${metric} in a facility for ${group}",
   sections: [
-    {
-      id: "residents",
-      lang: {
-        title: "Nationwide ${metric} among incarcerated people",
-        link: "Incarcerated People",
-        notes: {
-          // TODO: prune
-          confirmed:
-            "True case counts are likely higher and may be significantly higher than reported.",
-          confirmed_rate:
-            "Rates are calculated using a denominator of facility-level population as of February 2020. See our methodology to learn more about why we chose this approach.",
-          active:
-            "True case counts are likely higher and may be significantly higher than reported.",
-          active_rate:
-            "Rates are calculated using a denominator of facility-level population as of February 2020. See our methodology to learn more about why we chose this approach.",
-          deaths:
-            "True mortality counts are likely higher and may be significantly higher than reported.",
-          deaths_rate:
-            "Rates are calculated using a denominator of facility-level population as of February 2020. See our methodology to learn more about why we chose this approach. ",
-          tests:
-            "Some agencies report the number of persons tested, while others report the number of tests administered. We record whichever number is available.",
-          tests_rate:
-            "Rates are calculated using a denominator of facility-level population as of February 2020. See our methodology to learn more about why we chose this approach.",
-        },
-      },
-    },
     {
       id: "residents",
       lang: {
@@ -139,8 +119,7 @@ const content = {
             "True case counts are likely higher and may be significantly higher than reported",
           deaths_rate:
             "We do not have reliable data for staffing levels at all facilities. As a result, we are not currently providing rates for staff.",
-          tests:
-            "",
+          tests: "",
           tests_rate:
             "We do not have reliable data for staffing levels at all facilities. As a result, we are not currently providing rates for staff.",
         },
@@ -154,22 +133,22 @@ const content = {
         body: "",
       },
     },
-    // {
-    //   id: "filings",
-    //   lang: {
-    //     title: "Legal Filings and Court Orders Related to COVID-19",
-    //     link: "Filings & Court Orders",
-    //     body:
-    //       "Our project collaborates with Bronx Defenders, Columbia Law School’s Center for Institutional and Social Change, and Zealous to collect legal documents from around the country related to COVID-19 and incarceration. Together, we then organize and code them into the jointly managed <a href='https://healthisjustice.org/litigation-hub/login' rel='noreferrer' target='_blank'>Health is Justice litigation hub</a> for public defenders, litigators, and other advocates. The majority of the legal documents in the Health is Justice litigation hub are federal court opinions, but we are expanding to state legal filings, declarations, and exhibits.<br /><br />In addition to the Health is Justice litigation hub, our project also manages additional data self-reported by advocates regarding COVID-19-related legal filings involving <a href='https://docs.google.com/spreadsheets/d/1X6uJkXXS-O6eePLxw2e4JeRtM41uPZ2eRcOA_HkPVTk/edit#gid=1832796231' rel='noreferrer' target='_blank'>incarcerated youth</a> and <a href='https://docs.google.com/spreadsheets/d/1X6uJkXXS-O6eePLxw2e4JeRtM41uPZ2eRcOA_HkPVTk/edit#gid=22612814' rel='noreferrer' target='_blank'>individuals in immigration detention</a>.",
-    //     visual: {
-    //       courtCount: "number of courts",
-    //       granted: "compassionate releases granted",
-    //       facilityCount: "number of facilities",
-    //       total: "filings coded by our team",
-    //       unavailable: "No filings data available.",
-    //     },
-    //   },
-    // },
+    {
+      id: "filings",
+      lang: {
+        title: "Legal Filings and Court Orders Related to COVID-19",
+        link: "Filings & Court Orders",
+        body:
+          "Our project collaborates with Bronx Defenders, Columbia Law School’s Center for Institutional and Social Change, and Zealous to collect legal documents from around the country related to COVID-19 and incarceration. Together, we then organize and code them into the jointly managed <a href='https://healthisjustice.org/litigation-hub/login' rel='noreferrer' target='_blank'>Health is Justice litigation hub</a> for public defenders, litigators, and other advocates. The majority of the legal documents in the Health is Justice litigation hub are federal court opinions, but we are expanding to state legal filings, declarations, and exhibits.<br /><br />In addition to the Health is Justice litigation hub, our project also manages additional data self-reported by advocates regarding COVID-19-related legal filings involving <a href='https://docs.google.com/spreadsheets/d/1X6uJkXXS-O6eePLxw2e4JeRtM41uPZ2eRcOA_HkPVTk/edit#gid=1832796231' rel='noreferrer' target='_blank'>incarcerated youth</a> and <a href='https://docs.google.com/spreadsheets/d/1X6uJkXXS-O6eePLxw2e4JeRtM41uPZ2eRcOA_HkPVTk/edit#gid=22612814' rel='noreferrer' target='_blank'>individuals in immigration detention</a>.",
+        visual: {
+          courtCount: "number of courts",
+          granted: "compassionate releases granted",
+          facilityCount: "number of facilities",
+          total: "filings coded by our team",
+          unavailable: "No filings data available.",
+        },
+      },
+    },
     {
       id: "releases",
       lang: {
@@ -182,36 +161,6 @@ const content = {
         },
       },
     },
-    // {
-    //   id: "immigration",
-    //   lang: {
-    //     title: "COVID-19 Cases and Deaths in Immigration Detention",
-    //     link: "Immigration",
-    //     body:
-    //       "We collect data on COVID-19 infections and deaths of detainees and staff within all 120 U.S. Immigration and Customs Enforcement (ICE) facilities, as well as other facilities detaining people under ICE jurisdiction, across the United States. Our data come directly from ICE’s website and are updated almost every day. As of November 23, 2020, ICE no longer reports COVID-19-related cases and deaths among staff. View our <a href='https://docs.google.com/spreadsheets/d/1X6uJkXXS-O6eePLxw2e4JeRtM41uPZ2eRcOA_HkPVTk/edit#gid=278828877' rel='noreferrer' target='_blank'>full immigration dateset</a>.",
-    //     visual: {
-    //       facilityCount: "ICE facilities",
-    //       caseCount: "detainee cases",
-    //       deathsCount: "detainee deaths",
-    //     },
-    //   },
-    // },
-    // {
-    //   id: "grassroots",
-    //   lang: {
-    //     title:
-    //       "Grassroots and Community Organizing Efforts Related to COVID-19",
-    //     link: "Grassroots & Organizing",
-    //     body:
-    //       "Our team collects data on grassroots and community organizing efforts by incarcerated people, their families, community-based organizations, nonprofits, and advocates aimed at influencing government agencies to protect the lives of people incarcerated in prisons, jails, and detention centers against the threats posed by COVID-19. <a href='https://docs.google.com/spreadsheets/d/1X6uJkXXS-O6eePLxw2e4JeRtM41uPZ2eRcOA_HkPVTk/edit#gid=1720501154' rel='noreferrer' target='_blank'>View our full grassroots and organizing dataset</a>. ",
-    //     visual: {
-    //       effortCount: "efforts",
-    //       internalCount: "efforts happening behind bars",
-    //       externalCount: "efforts started externally",
-    //       coordinatedCount: "coordinated efforts (inside and outside)",
-    //     },
-    //   },
-    // },
   ],
 }
 
@@ -221,16 +170,12 @@ const SECTION_COMPONENTS = {
   facilities: Facilities,
   filings: Filings,
   releases: Releases,
-  // immigration: Immigration,
-  // grassroots: Grassroots,
 }
 
 const StateTemplate = ({ pageContext, data }) => {
   // classes used on this page
   const classes = useStyles()
-  // pull state name from page context
-  // const { state } = pageContext
-  const state = "federal"
+  const state = "Federal"
   // track current step index for scrollytelling
   const [
     currentStep,
@@ -257,12 +202,10 @@ const StateTemplate = ({ pageContext, data }) => {
 
   // update current step when entering
   const handleStepEnter = ({ data }) => {
-    console.log('hse: ', data)
     setCurrentStep(data)
   }
 
   const handleNavigation = (section) => {
-    console.log("seciton", section)
     navigate("#" + section)
     setCurrentStep(section)
   }
@@ -286,16 +229,14 @@ const StateTemplate = ({ pageContext, data }) => {
           <Scrollama onStepEnter={handleStepEnter}>
             {content.sections.map((section, index) => {
               const Component = SECTION_COMPONENTS[section.id]
-              console.log("||", section.id, "||", Component)
               return (
                 <Step key={section.id} data={section.id}>
                   <div id={section.id}>
                     {index === 0 && (
                       <Typography variant="h2" className={classes.title}>
-                        {state}ihhi
+                        United States
                       </Typography>
                     )}
-                    <div>{index}!</div>
                     <Component
                       isFederal={true}
                       className={clsx(classes.step, {
@@ -341,7 +282,6 @@ export const query = graphql`
             deaths
             recovered
           }
-          state
         }
       }
     }
@@ -354,6 +294,16 @@ export const query = graphql`
           source
           state
           capacity
+        }
+      }
+    }
+    allFilings(filter: { state: { eq: "federal" } }) {
+      edges {
+        node {
+          courtCount
+          facilityCount
+          granted
+          total
         }
       }
     }

--- a/packages/gatsby-ucla-site/src/components/states/JurisdictionStatList.js
+++ b/packages/gatsby-ucla-site/src/components/states/JurisdictionStatList.js
@@ -65,6 +65,7 @@ const JurisdictionStatList = ({
 
   const isRateSelected = metric.split("_").pop() === "rate"
   const jurisdictions = isFederal ? ["federal"] : JURISDICTIONS
+
   return (
     <Stack className={clsx(classes.root, className)} spacing={2}>
       {jurisdictions.map((jurisdiction) => (
@@ -81,7 +82,7 @@ const JurisdictionStatList = ({
           <NumberStat
             className={classes.stat}
             value={getGroupData(jurisdiction, baseMetric)}
-            isSelectedMetric={!isRateSelected}
+            secondary={isRateSelected}
             label={getLang(baseMetric, "label")}
           ></NumberStat>
           {groupHasRates(group) && (
@@ -89,7 +90,7 @@ const JurisdictionStatList = ({
               className={classes.stat}
               value={getGroupData(jurisdiction, baseMetric, true)}
               label={getLang(baseMetric, "rate")}
-              isSelectedMetric={isRateSelected}
+              secondary={!isRateSelected}
               format={(n) => formatMetricValue(n, getKey(baseMetric, "rate"))} // d3Format expects decimal
             ></NumberStat>
           )}

--- a/packages/gatsby-ucla-site/src/components/states/JurisdictionStatList.js
+++ b/packages/gatsby-ucla-site/src/components/states/JurisdictionStatList.js
@@ -51,6 +51,7 @@ const JurisdictionStatList = ({
   metric,
   group,
   groupData,
+  isFederal,
 }) => {
   const baseMetric = metric.split("_")[0]
   const getGroupData = (jurisdiction, metric, isRate) => {
@@ -63,9 +64,10 @@ const JurisdictionStatList = ({
   }
 
   const isRateSelected = metric.split("_").pop() === "rate"
+  const jurisdictions = isFederal ? ["federal"] : JURISDICTIONS
   return (
     <Stack className={clsx(classes.root, className)} spacing={2}>
-      {JURISDICTIONS.map((jurisdiction) => (
+      {jurisdictions.map((jurisdiction) => (
         <Stack
           key={jurisdiction}
           className={classes.jurisdictionContainer}

--- a/packages/gatsby-ucla-site/src/components/states/sections/Facilities.js
+++ b/packages/gatsby-ucla-site/src/components/states/sections/Facilities.js
@@ -24,9 +24,9 @@ const Facilities = ({ id, lang, data, isFederal, ...props }) => {
   )
 
   // get facilities for current state
-  const facilities = isFederal ?
-    all.filter((f) => f.jurisdiction === "federal") :
-    all.filter((f) => f.state === stateName)
+  const facilities = isFederal
+    ? all.filter((f) => f.jurisdiction === "federal")
+    : all.filter((f) => f.state === stateName)
 
   // handler for when table headers are clicked
   const handleFacilitiesGroupChange = React.useCallback(

--- a/packages/gatsby-ucla-site/src/components/states/sections/Facilities.js
+++ b/packages/gatsby-ucla-site/src/components/states/sections/Facilities.js
@@ -7,7 +7,7 @@ import shallow from "zustand/shallow"
 import useStatesStore from "../useStatesStore"
 import { useActiveMetric, useFacilitiesData } from "../../../common/hooks"
 
-const Facilities = ({ id, lang, data, ...props }) => {
+const Facilities = ({ id, lang, data, isFederal, ...props }) => {
   const all = useFacilitiesData()
 
   // currently selected metric
@@ -24,7 +24,9 @@ const Facilities = ({ id, lang, data, ...props }) => {
   )
 
   // get facilities for current state
-  const facilities = all.filter((f) => f.state === stateName)
+  const facilities = isFederal ?
+    all.filter((f) => f.jurisdiction === "federal") :
+    all.filter((f) => f.state === stateName)
 
   // handler for when table headers are clicked
   const handleFacilitiesGroupChange = React.useCallback(
@@ -45,6 +47,7 @@ const Facilities = ({ id, lang, data, ...props }) => {
         group={facilitiesGroup}
         data={facilities}
         onSort={handleFacilitiesGroupChange}
+        isFederal={isFederal}
       />
     </Stack>
   )

--- a/packages/gatsby-ucla-site/src/components/states/sections/Filings.js
+++ b/packages/gatsby-ucla-site/src/components/states/sections/Filings.js
@@ -3,11 +3,30 @@ import Stack from "../../Stack"
 import { Grid, Typography } from "@material-ui/core"
 import HealthJustice from "../../../../content/assets/health-justice-logo.png"
 import NumberStat from "../../stats/NumberStat"
+import shallow from "zustand/shallow"
+import useStatesStore from "../useStatesStore"
 
-const Filings = ({ id, lang, data, ...props }) => {
+const Filings = ({ id, lang, data, isFederal, ...props }) => {
+  const content = useStatesStore((state) => state.content, shallow)
+  let federalStat = null
+  if (isFederal) {
+    const filingsData = data.allFilings?.edges[0]?.node
+    const labels = content.sections.find((s) => s.id === "filings").lang.visual
+    federalStat = (
+      <Grid className="embedded-stats" container spacing={4}>
+        {Object.keys(filingsData).map((key) => (
+          <Grid key={key} item xs={6}>
+            <NumberStat value={filingsData[key]} label={labels[key]} />
+          </Grid>
+        ))}
+      </Grid>
+    )
+  }
+
   return (
     <Stack {...props}>
       <Typography variant="h3">{lang.title}</Typography>
+      {federalStat}
       {lang.body && (
         <Typography
           variant="body1"

--- a/packages/gatsby-ucla-site/src/components/states/sections/Releases.js
+++ b/packages/gatsby-ucla-site/src/components/states/sections/Releases.js
@@ -12,7 +12,13 @@ const Releases = ({ id, lang, data, isFederal, ...props }) => {
     const releaseCount = data.allPrisonReleases?.edges?.length
     const label = content.sections.find((s) => s.id === "releases").lang.visual
       .prisonCount
-    federalStat = <NumberStat value={releaseCount} label={label} />
+    federalStat = (
+      <NumberStat
+        className="embedded-stats"
+        value={releaseCount}
+        label={label}
+      />
+    )
   }
   return (
     <Stack {...props}>

--- a/packages/gatsby-ucla-site/src/components/states/sections/Releases.js
+++ b/packages/gatsby-ucla-site/src/components/states/sections/Releases.js
@@ -1,11 +1,23 @@
 import React from "react"
 import Stack from "../../Stack"
 import { Typography } from "@material-ui/core"
+import NumberStat from "../../stats/NumberStat"
+import useStatesStore from "../useStatesStore"
+import shallow from "zustand/shallow"
 
-const Releases = ({ id, lang, data, ...props }) => {
+const Releases = ({ id, lang, data, isFederal, ...props }) => {
+  const content = useStatesStore((state) => state.content, shallow)
+  let federalStat = null
+  if (isFederal) {
+    const releaseCount = data.allPrisonReleases?.edges?.length
+    const label = content.sections.find((s) => s.id === "releases").lang.visual
+      .prisonCount
+    federalStat = <NumberStat value={releaseCount} label={label} />
+  }
   return (
     <Stack {...props}>
       <Typography variant="h3">{lang.title}</Typography>
+      {federalStat}
       {lang.body && (
         <Typography
           variant="body1"

--- a/packages/gatsby-ucla-site/src/components/states/sections/ResidentsSummary.js
+++ b/packages/gatsby-ucla-site/src/components/states/sections/ResidentsSummary.js
@@ -32,14 +32,13 @@ const ResidentsSummary = ({
     lang.notes && lang.notes[metric + "_rate"],
   ].filter((n) => !!n)
 
-  const group = isFederal ? "residentsFederal" : "residents"
   return (
     <Stack className={clsx(classes.root, className)} {...props}>
-      <MetricSelectionTitle title={lang.title} group={group} />
+      <MetricSelectionTitle title={lang.title} group="residents" />
       <JurisdictionStatList
         isFederal={isFederal}
         metric={metric}
-        group={group}
+        group="residents"
         groupData={summary["residents"]}
       />
       {notes.length > 0 && <Notes notes={notes} />}

--- a/packages/gatsby-ucla-site/src/components/states/sections/ResidentsSummary.js
+++ b/packages/gatsby-ucla-site/src/components/states/sections/ResidentsSummary.js
@@ -10,25 +10,36 @@ import { summaryStyles as styles } from "./styles"
 import Notes from "../Notes"
 import MetricSelectionTitle from "../../controls/MetricSelectionTitle"
 
-const ResidentsSummary = ({ id, lang, data, classes, className, ...props }) => {
+const ResidentsSummary = ({
+  id,
+  lang,
+  data,
+  classes,
+  className,
+  isFederal,
+  ...props
+}) => {
   // data for all facilities in the state
   const all = data.allFacilities.edges.map((d) => d.node)
 
   // jurisdiction totals for the state
   const summary = getDataByJurisdiction(all)
-  
+
   // metric for the stat list
   const metric = useActiveMetric()
   const notes = [
     lang.notes && lang.notes[metric],
     lang.notes && lang.notes[metric + "_rate"],
   ].filter((n) => !!n)
+
+  const group = isFederal ? "residentsFederal" : "residents"
   return (
     <Stack className={clsx(classes.root, className)} {...props}>
-      <MetricSelectionTitle title={lang.title} group="residents" />
+      <MetricSelectionTitle title={lang.title} group={group} />
       <JurisdictionStatList
+        isFederal={isFederal}
         metric={metric}
-        group="residents"
+        group={group}
         groupData={summary["residents"]}
       />
       {notes.length > 0 && <Notes notes={notes} />}

--- a/packages/gatsby-ucla-site/src/components/states/sections/StaffSummary.js
+++ b/packages/gatsby-ucla-site/src/components/states/sections/StaffSummary.js
@@ -9,7 +9,7 @@ import { getLang } from "../../../common/utils/i18n"
 import MetricSelectionTitle from "../../controls/MetricSelectionTitle"
 import Notes from "../Notes"
 
-const StaffSummary = ({ id, lang, data, ...props }) => {
+const StaffSummary = ({ id, lang, data, isFederal, ...props }) => {
   // data for all facilities in the state
   const all = data.allFacilities.edges.map((d) => d.node)
   // jurisdiction totals for the state
@@ -25,6 +25,7 @@ const StaffSummary = ({ id, lang, data, ...props }) => {
       <MetricSelectionTitle title={lang.title} group="staff" />
       {isStaffMetric && (
         <JurisdictionStatList
+          isFederal={isFederal}
           metric={metric}
           group="staff"
           groupData={summary["staff"]}

--- a/packages/gatsby-ucla-site/src/components/states/states.js
+++ b/packages/gatsby-ucla-site/src/components/states/states.js
@@ -234,7 +234,6 @@ const StateTemplate = ({ pageContext, data }) => {
   }
 
   const handleNavigation = (section) => {
-    console.log("seciton", section)
     navigate("#" + section)
     setCurrentStep(section)
   }

--- a/packages/gatsby-ucla-site/src/components/stats/NumberStat.js
+++ b/packages/gatsby-ucla-site/src/components/stats/NumberStat.js
@@ -13,7 +13,7 @@ export const styles = (theme) => ({
   number: {
     fontSize: theme.typography.pxToRem(32),
     color: theme.palette.secondary.secondary,
-    "&.selected": {
+    "&.highlighted": {
       color: theme.palette.secondary.main,
     },
     fontWeight: 700,
@@ -39,7 +39,7 @@ const NumberStat = ({
   value,
   label,
   format = ",d",
-  isSelectedMetric,
+  secondary,
   children,
   ...props
 }) => {
@@ -57,7 +57,7 @@ const NumberStat = ({
     >
       <Typography
         className={clsx(classes.number, {
-          selected: isSelectedMetric,
+          highlighted: !secondary,
         })}
         variant="number"
       >
@@ -76,7 +76,7 @@ NumberStat.propTypes = {
   className: PropTypes.string,
   value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   label: PropTypes.string,
-  isSelectedMetric: PropTypes.bool,
+  secondary: PropTypes.bool,
 }
 
 export default withStyles(styles)(NumberStat)

--- a/packages/gatsby-ucla-site/src/gatsby-theme-hyperobjekt-core/theme.js
+++ b/packages/gatsby-ucla-site/src/gatsby-theme-hyperobjekt-core/theme.js
@@ -228,6 +228,9 @@ const CovidTheme = () => {
           "&.page.page--states .content": {
             maxWidth: "none",
           },
+          "&.page.page--federal .content": {
+            maxWidth: "none",
+          },
         },
       },
       /** Header style overrides */


### PR DESCRIPTION
#44 will leave open in case there's more

@Lane @lougroshek @james-minton FYI that this is going in. You can see it at /federal, and I added it as United States at the end of the State & Federal Data dropdown menu.

Kept the structure almost identical to the one for states, so that when/if we want to implement the map/visuals on the right it's set up for it. The stats that display on the right for states are instead embedded in the text chunk (ie in Filings/Releases, since FilingsVisual/ReleasesVisual isn't used) -- see image below. I used a prop isFederal for the conditional logic, perhaps I should've instead used the "state" value in the store instead. Also, the Filings section comes before the Releases section for states, but the content doc has the reverse listed for the Federal page; I left in the same order as for states, could be swapped.

Many values seem to be null, including most (all?) rates.

<img width="1233" alt="Screen Shot 2020-12-14 at 1 12 09 PM" src="https://user-images.githubusercontent.com/18331999/102118744-2075fe00-3e0e-11eb-9b56-798578fdfa81.png">
