### PR TITLE
Fix/67 incorrect data - fixes #67

### DIFF
--- a/packages/gatsby-ucla-site/gatsby-node.js
+++ b/packages/gatsby-ucla-site/gatsby-node.js
@@ -103,10 +103,6 @@ exports.createPages = async ({ graphql, actions }) => {
   createPage({
     path: `/federal/`,
     component: FederalPage,
-    context: {
-      // TODO: delete
-      slug: "fed",
-      state: "feda",
-    },
+    context: {},
   })
 }

--- a/packages/gatsby-ucla-site/src/common/utils/formatters.js
+++ b/packages/gatsby-ucla-site/src/common/utils/formatters.js
@@ -3,6 +3,7 @@ import { METRIC_FORMATTERS } from "../constants"
 export const formatMetricValue = (value, metric) => {
   const format = METRIC_FORMATTERS[metric] || ((d) => d)
   if (typeof value !== "number" || !Number.isFinite(value)) {
+    // fixes #55
     return "N/A"
   }
   return format(value)

--- a/packages/gatsby-ucla-site/src/components/maps/MapLegend.js
+++ b/packages/gatsby-ucla-site/src/components/maps/MapLegend.js
@@ -9,6 +9,7 @@ import { extent } from "d3-array"
 import { getDataMetricSelector } from "../../common/utils"
 import { formatMetricValue } from "../../common/utils/formatters"
 import JurisdictionToggles from "../controls/JurisdictionToggles"
+import useStatesStore from "../states/useStatesStore"
 
 const styles = (theme) => ({
   root: {
@@ -31,9 +32,20 @@ const SpikeLegend = ({ data, sizeRange = [1, 60] }) => {
     (state) => [state.categoryColors, state.categoryGradients],
     shallow
   )
+  const [currentStep, facilitiesGroup] = useStatesStore(
+    (state) => [state.currentStep, state.facilitiesGroup],
+    shallow
+  )
   const metric = useActiveMetric()
-  const accessor = getDataMetricSelector(metric)
+
+  const legendGroup = (() => {
+    if (currentStep === "staff") return "staff"
+    if (currentStep === "facilities") return facilitiesGroup
+    return "residents"
+  })()
+  const accessor = getDataMetricSelector(metric, legendGroup)
   const dataExtent = extent(data, accessor)
+
   const isRate = metric.indexOf("_rate") > -1
   const formatId = isRate ? "rate_legend" : "count_legend"
   const spikeLabels = [isRate ? 0 : 1, dataExtent[1] / 2, dataExtent[1]].map(

--- a/packages/gatsby-ucla-site/src/components/maps/MapLegend.js
+++ b/packages/gatsby-ucla-site/src/components/maps/MapLegend.js
@@ -50,6 +50,10 @@ const SpikeLegend = ({ data, sizeRange = [1, 60] }) => {
   const formatId = isRate ? "rate_legend" : "count_legend"
   const spikeLabels = [isRate ? 0 : 1, dataExtent[1] / 2, dataExtent[1]].map(
     (d) => {
+      if (!isRate && d < 1) {
+        // when max value is 0 or 1
+        return "N/A"
+      }
       const value = formatMetricValue(d, formatId)
       const parts = value.split(".")
       // if integer with .0 ending, return only the integer part

--- a/packages/gatsby-ucla-site/src/components/maps/MarkerLayer/MarkerLayer.js
+++ b/packages/gatsby-ucla-site/src/components/maps/MarkerLayer/MarkerLayer.js
@@ -63,47 +63,48 @@ const MarkerLayer = ({
 
   return (
     <g className={clsx("spike-layer", classes.root, className)} {...props}>
-      {markers.map((marker, i) => {
-        const size = getValue(getMarkerSize, marker)
-        if (size <= 0) {
-          // fixes #53 - avoid negative spikes
-          return null
-        }
-        const width = getValue(getSpikeWidth, marker)
-        const color = getValue(getColor, marker)
-        const stroke = getValue(getStroke, marker)
-        const label = getValue(labelValue, marker)
-        const highlight = getValue(highlightValue, marker)
-        const coords = marker.coords
-        return (
-          <Marker
-            key={marker.id}
-            coordinates={coords}
-            className={classes.marker}
-          >
-            {type === "dots" && (
-              <Dot
-                radius={size}
-                stroke={stroke}
-                fill={color}
-                fillOpacity={getValue(getCircleOpacity, marker)}
-              />
-            )}
-            {type === "spikes" && (
-              <Spike
-                fill={color}
-                stroke={stroke}
-                length={size}
-                width={width}
-                className={clsx(classes.spike, {
-                  [classes.highlight]: highlight,
-                })}
-              />
-            )}
-            {label && <text className={classes.text}>{label}</text>}
-          </Marker>
-        )
-      })}
+      {!!sizeExtent[1] && // fixes #67 - if max size is 0, don't plot spikes
+        markers.map((marker, i) => {
+          const size = getValue(getMarkerSize, marker)
+          if (size <= 0) {
+            // fixes #53 - avoid negative spikes
+            return null
+          }
+          const width = getValue(getSpikeWidth, marker)
+          const color = getValue(getColor, marker)
+          const stroke = getValue(getStroke, marker)
+          const label = getValue(labelValue, marker)
+          const highlight = getValue(highlightValue, marker)
+          const coords = marker.coords
+          return (
+            <Marker
+              key={marker.id}
+              coordinates={coords}
+              className={classes.marker}
+            >
+              {type === "dots" && (
+                <Dot
+                  radius={size}
+                  stroke={stroke}
+                  fill={color}
+                  fillOpacity={getValue(getCircleOpacity, marker)}
+                />
+              )}
+              {type === "spikes" && (
+                <Spike
+                  fill={color}
+                  stroke={stroke}
+                  length={size}
+                  width={width}
+                  className={clsx(classes.spike, {
+                    [classes.highlight]: highlight,
+                  })}
+                />
+              )}
+              {label && <text className={classes.text}>{label}</text>}
+            </Marker>
+          )
+        })}
       {children}
     </g>
   )

--- a/packages/gatsby-ucla-site/src/components/states/states.js
+++ b/packages/gatsby-ucla-site/src/components/states/states.js
@@ -233,10 +233,10 @@ const StateTemplate = ({ pageContext, data }) => {
     setCurrentStep(data)
   }
 
-  const handleNavigation = (section) => {
-    navigate("#" + section)
-    setCurrentStep(section)
-  }
+  // const handleNavigation = (section) => {
+  //   navigate("#" + section)
+  //   setCurrentStep(section)
+  // }
 
   // setctions for section nav
   const sections = content.sections.map((s) => ({
@@ -249,7 +249,7 @@ const StateTemplate = ({ pageContext, data }) => {
       <SectionNavigation
         current={currentStep}
         sections={sections}
-        onSelect={handleNavigation}
+        // onSelect={handleNavigation}
       />
       <ResponsiveContainer>
         <Visual className={classes.visual} />


### PR DESCRIPTION
#67 

- legend wasn't updating because it's values weren't tied to the current step (always pulled values for "residents", even when scrolled to "staff" or "facilities")
- when extent of data is 0, don't plot any markers
- somewhat relatedly, added logic so that legend spike labels read N/A for values less than 1 (if extent of data is 1, the smaller spike label was marked "500m", and if extent is 0 both spikes were marked 0)