### PR TITLE
fixes #58 (DC)

### DIFF
--- a/packages/gatsby-ucla-site/scripts/parseData.js
+++ b/packages/gatsby-ucla-site/scripts/parseData.js
@@ -50,6 +50,11 @@ const UPPER_CASE = [
 ]
 
 /**
+ * All ways DC is represented in source data (in lower case)
+ */
+const DC_VARIANTS = ["dc", "district of columbia", "district of col"]
+
+/**
  * Fixes casing on strings THAT ARE ALL UPPERCASE
  * so that They Have Title Casing
  * @param {string} str
@@ -65,6 +70,16 @@ function fixCasing(str) {
     )
     .join(" ")
   return result
+}
+
+/**
+ * Fixes for inconsistent state naming
+ * @param {string} str
+ */
+function formatState(str) {
+  return DC_VARIANTS.includes(str.toLowerCase())
+   ? "District of Columbia"
+   : str
 }
 
 /**
@@ -108,7 +123,7 @@ const parseFacility = (facility = {}) => {
   result.name = fixCasing(source.name)
   result.jurisdiction = source["jurisdiction"]
   result.city = source["city"]
-  result.state = source["state"]
+  result.state = formatState(source["state"])
   result.date = Date.parse(source["date"])
 
   // parse coordinates
@@ -190,6 +205,10 @@ const parseMap = (row, colMap) => {
     let parsedValue = valueParser(rawValue)
     if ((parser === "int" || parser === "float") && isNaN(parsedValue))
       parsedValue = null
+
+    if (colName === "state") {
+      parsedValue = formatState(parsedValue)
+    }
     result[colName] = parsedValue
   })
   return result

--- a/packages/gatsby-ucla-site/src/common/data/us_state_centers.json
+++ b/packages/gatsby-ucla-site/src/common/data/us_state_centers.json
@@ -57,7 +57,8 @@
     "State": "District of Columbia",
     "StateCode": "DC",
     "Latitude": 38.8974,
-    "Longitude": -77.0268
+    "Longitude": -77.0268,
+    "scale": 120000
   },
   "FL": {
     "State": "Florida",


### PR DESCRIPTION
standardize DC spellings, zoom in

DC still has limited data (and nothing for the map), but should be sourcing it correctly now.

fyi @james-minton it's going in - you can tweak that scale value if you want to de-emphasize the empty map...