### PR TITLE
Fix/248 legend formatting

### DIFF
--- a/packages/gatsby-ucla-site/content/en.json
+++ b/packages/gatsby-ucla-site/content/en.json
@@ -42,5 +42,6 @@
   "state_summary_title": "Summary",
   "unavailable": "Unavailable",
   "nat_map_title": "This map displays COVID-19 cases and related deaths of people incarcerated in prisons and jails across the US. Click on a state to access more data.",
-  "state_map_title": "Map of ${stateName} with spikes representing the active metric for each facility."
+  "state_map_title": "Map of ${stateName} with spikes representing the active metric for each facility.",
+  "empty_legend_message": "no data available"
 }

--- a/packages/gatsby-ucla-site/src/common/constants.js
+++ b/packages/gatsby-ucla-site/src/common/constants.js
@@ -27,6 +27,14 @@ export const METRICS = {
     "active_rate",
     "tested_rate",
   ],
+  immigration: [
+    "confirmed",
+    "deaths",
+    "active",
+    "confirmed_rate",
+    "deaths_rate",
+    "active_rate",
+  ],
   staff: ["confirmed", "deaths", "active", "tested"],
 }
 

--- a/packages/gatsby-ucla-site/src/components/controls/MetricSelection.js
+++ b/packages/gatsby-ucla-site/src/components/controls/MetricSelection.js
@@ -4,13 +4,23 @@ import { useOptionsStore } from "../../common/hooks"
 import { METRICS, GROUPS } from "../../common/constants"
 import GenericSelection from "./GenericSelection"
 
-const MetricSelection = ({ classes, className, group, ...props }) => {
+const MetricSelection = ({
+  classes,
+  className,
+  group,
+  isImmigration,
+  ...props
+}) => {
   const [metric, setMetric] = useOptionsStore(
     (state) => [state.metric, state.setMetric],
     shallow
   )
-  // get available metrics, or default to first group
-  const metrics = group ? METRICS[group] : METRICS[GROUPS[0]]
+  // use immigration metrics. otherwise get available metrics, or default to first group
+  const metrics = isImmigration
+    ? METRICS.immigration
+    : group
+    ? METRICS[group]
+    : METRICS[GROUPS[0]]
 
   return (
     <GenericSelection

--- a/packages/gatsby-ucla-site/src/components/controls/MetricSelectionTitle.js
+++ b/packages/gatsby-ucla-site/src/components/controls/MetricSelectionTitle.js
@@ -36,10 +36,13 @@ const MetricSelectionTitle = ({
   /* eslint-disable no-template-curly-in-string */
   const titleParts = title.split("${metric}")
   /* eslint-enable no-template-curly-in-string */
+  const metricSelection = (
+    <MetricSelection group={group} isImmigration={isImmigration} />
+  )
   const titleArray =
     titleParts.length === 2
-      ? [titleParts[0], <MetricSelection group={group} />, titleParts[1]]
-      : [...titleParts, <MetricSelection group={group} />]
+      ? [titleParts[0], metricSelection, titleParts[1]]
+      : [...titleParts, metricSelection]
 
   const regionSelected = useOptionsStore((state) => state.iceRegionId)
   let regionTitleArray = []

--- a/packages/gatsby-ucla-site/src/components/home/HomeTable.js
+++ b/packages/gatsby-ucla-site/src/components/home/HomeTable.js
@@ -157,27 +157,36 @@ const HomeTable = ({
       },
     }
 
-    const colNames = [
-      "confirmed",
-      "confirmed_rate",
-      "active",
-      "active_rate",
-      "deaths",
-      "deaths_rate",
-      "tested",
-      "tested_rate",
-    ]
+    const colMetrics = isImmigration
+      ? [
+          "confirmed",
+          "confirmed_rate",
+          "active",
+          "active_rate",
+          "deaths",
+          "deaths_rate",
+        ]
+      : [
+          "confirmed",
+          "confirmed_rate",
+          "active",
+          "active_rate",
+          "deaths",
+          "deaths_rate",
+          "tested",
+          "tested_rate",
+        ]
 
-    const cols = colNames.map((cn) => {
+    const cols = colMetrics.map((colMetric) => {
       const col = {
-        id: cn,
-        Header: getLang(cn),
-        accessor: `residents.${cn}`,
+        id: colMetric,
+        Header: getLang(colMetric),
+        accessor: `residents.${colMetric}`,
         Cell: (prop) => countFormatter(prop.value),
         style: numberColStyle,
       }
 
-      const isRate = cn.indexOf("_rate") > 0
+      const isRate = colMetric.indexOf("_rate") > 0
       if (isRate) {
         col.sortType = rateSorter
         col.Cell = (prop) => rateFormatter(prop.value)

--- a/packages/gatsby-ucla-site/src/components/maps/MapLegend.js
+++ b/packages/gatsby-ucla-site/src/components/maps/MapLegend.js
@@ -79,30 +79,30 @@ const SpikeLegend = ({ data, sizeRange = [1, 60] }) => {
       ) : (
         <>
           {!singleValueMapped && (
-            <Stack align="center" spacing={0.5}>
-              <SpikeMarker
-                height={sizeRange[0]}
-                width={7}
-                stroke={categoryColors[4]}
-                fill={categoryGradients[4]}
-              />
-              <Typography className={classes.label} variant="body2">
-                {spikeLabels[0]}
-              </Typography>
-            </Stack>
-          )}
-          {!singleValueMapped && (
-            <Stack align="center" spacing={0.5}>
-              <SpikeMarker
-                height={sizeRange[1] / 2}
-                width={7}
-                stroke={categoryColors[4]}
-                fill={categoryGradients[4]}
-              />
-              <Typography className={classes.label} variant="body2">
-                {spikeLabels[1]}
-              </Typography>
-            </Stack>
+            <>
+              <Stack align="center" spacing={0.5}>
+                <SpikeMarker
+                  height={sizeRange[0]}
+                  width={7}
+                  stroke={categoryColors[4]}
+                  fill={categoryGradients[4]}
+                />
+                <Typography className={classes.label} variant="body2">
+                  {spikeLabels[0]}
+                </Typography>
+              </Stack>
+              <Stack align="center" spacing={0.5}>
+                <SpikeMarker
+                  height={sizeRange[1] / 2}
+                  width={7}
+                  stroke={categoryColors[4]}
+                  fill={categoryGradients[4]}
+                />
+                <Typography className={classes.label} variant="body2">
+                  {spikeLabels[1]}
+                </Typography>
+              </Stack>
+            </>
           )}
           <Stack align="center" spacing={0.5}>
             <SpikeMarker

--- a/packages/gatsby-ucla-site/src/components/maps/MapLegend.js
+++ b/packages/gatsby-ucla-site/src/components/maps/MapLegend.js
@@ -10,6 +10,7 @@ import { getDataMetricSelector } from "../../common/utils"
 import { formatMetricValue } from "../../common/utils/formatters"
 import JurisdictionToggles from "../controls/JurisdictionToggles"
 import useStatesStore from "../states/useStatesStore"
+import { getLang } from "../../common/utils/i18n"
 
 const styles = (theme) => ({
   root: {
@@ -45,6 +46,11 @@ const SpikeLegend = ({ data, sizeRange = [1, 60] }) => {
   })()
   const accessor = getDataMetricSelector(metric, legendGroup)
   const dataExtent = extent(data, accessor)
+  const noValuesMapped = !dataExtent[1]
+  // check if there is only a single non-zero value
+  const singleValueMapped = data.every(
+    (d) => !accessor(d) || accessor(d) === dataExtent[1]
+  )
 
   const isRate = metric.indexOf("_rate") > -1
   const formatId = isRate ? "rate_legend" : "count_legend"
@@ -66,39 +72,51 @@ const SpikeLegend = ({ data, sizeRange = [1, 60] }) => {
   )
   return (
     <Stack horizontal spacing={1} align="bottom">
-      <Stack align="center" spacing={0.5}>
-        <SpikeMarker
-          height={sizeRange[0]}
-          width={7}
-          stroke={categoryColors[4]}
-          fill={categoryGradients[4]}
-        />
-        <Typography className={classes.label} variant="body2">
-          {spikeLabels[0]}
+      {noValuesMapped ? (
+        <Typography variant="body2">
+          {getLang("empty_legend_message")}
         </Typography>
-      </Stack>
-      <Stack align="center" spacing={0.5}>
-        <SpikeMarker
-          height={sizeRange[1] / 2}
-          width={7}
-          stroke={categoryColors[4]}
-          fill={categoryGradients[4]}
-        />
-        <Typography className={classes.label} variant="body2">
-          {spikeLabels[1]}
-        </Typography>
-      </Stack>
-      <Stack align="center" spacing={0.5}>
-        <SpikeMarker
-          height={sizeRange[1]}
-          width={7}
-          stroke={categoryColors[4]}
-          fill={categoryGradients[4]}
-        />
-        <Typography className={classes.label} variant="body2">
-          {spikeLabels[2]}
-        </Typography>
-      </Stack>
+      ) : (
+        <>
+          {!singleValueMapped && (
+            <Stack align="center" spacing={0.5}>
+              <SpikeMarker
+                height={sizeRange[0]}
+                width={7}
+                stroke={categoryColors[4]}
+                fill={categoryGradients[4]}
+              />
+              <Typography className={classes.label} variant="body2">
+                {spikeLabels[0]}
+              </Typography>
+            </Stack>
+          )}
+          {!singleValueMapped && (
+            <Stack align="center" spacing={0.5}>
+              <SpikeMarker
+                height={sizeRange[1] / 2}
+                width={7}
+                stroke={categoryColors[4]}
+                fill={categoryGradients[4]}
+              />
+              <Typography className={classes.label} variant="body2">
+                {spikeLabels[1]}
+              </Typography>
+            </Stack>
+          )}
+          <Stack align="center" spacing={0.5}>
+            <SpikeMarker
+              height={sizeRange[1]}
+              width={7}
+              stroke={categoryColors[4]}
+              fill={categoryGradients[4]}
+            />
+            <Typography className={classes.label} variant="body2">
+              {spikeLabels[2]}
+            </Typography>
+          </Stack>
+        </>
+      )}
     </Stack>
   )
 }


### PR DESCRIPTION
Fixes #248 and fixes #249 (for all instances of MapLegend, not just Immigration). Also removes the `tested` metrics from Immigration map (which Liz requested, meant to do that before). 