### PR TITLE
Feature/321 reports cms

### DIFF
--- a/packages/gatsby-ucla-site/config/metadata.json
+++ b/packages/gatsby-ucla-site/config/metadata.json
@@ -172,8 +172,13 @@
           "type": "internal"
         },
         {
-          "name": "Resources & Reports",
+          "name": "Resources",
           "link": "/resources",
+          "type": "internal"
+        },
+        {
+          "name": "Reports",
+          "link": "/reports",
           "type": "internal"
         }
       ]

--- a/packages/gatsby-ucla-site/content/federal.json
+++ b/packages/gatsby-ucla-site/content/federal.json
@@ -68,12 +68,12 @@
           "cases_residents": "Cumulative Cases",
           "deaths_residents": "Cumulative Deaths",
           "active_residents": "Active Cases",
-          "tests_residents": "Tests",
+          "tests_residents": "Tests Administered",
           "population_residents": "Total Population",
           "vaccinations_residents": "Vaccinations",
           "cases_staff": "Cumulative Cases",
           "deaths_staff": "Cumulative Deaths",
-          "tests_staff": "Tests",
+          "tests_staff": "Tests Administered",
           "vaccinations_staff": "Vaccinations"
         },
         "table_value": {

--- a/packages/gatsby-ucla-site/content/immigration.json
+++ b/packages/gatsby-ucla-site/content/immigration.json
@@ -22,12 +22,12 @@
         "cases_residents": "Cumulative Cases",
         "deaths_residents": "Cumulative Deaths",
         "active_residents": "Active Cases",
-        "tests_residents": "Tests",
+        "tests_residents": "Tests Administered",
         "population_residents": "Total Population",
         "vaccinations_residents": "Vaccinations",
         "cases_staff": "Cumulative Cases",
         "deaths_staff": "Cumulative Deaths",
-        "tests_staff": "Tests",
+        "tests_staff": "Tests Administered",
         "vaccinations_staff": "Vaccinations"
       },
       "table_value": {

--- a/packages/gatsby-ucla-site/content/pages/index.mdx
+++ b/packages/gatsby-ucla-site/content/pages/index.mdx
@@ -25,23 +25,6 @@ table:
 vaccineTable:
   title: COVID-19 Vaccines in Carceral Facilities
   subtitle: (set vaccine_subtitle in en.json used instead for markup)
-reports:
-  - date: 2020-07-08T20:04:00.559Z
-    description: A study using our data finding that, from March to June, 2020, the
-      COVID-19 case rate for incarcerated people was 5.5 times higher than the
-      overall US population case rate. Their age-adjusted death rate was 3.0
-      times higher.
-    url: https://jamanetwork.com/journals/jama/fullarticle/2768249
-    author: JAMA Network
-    title: COVID-19 Cases and Deaths in Federal and State Prisons
-  - date: 2021-04-20T20:04:24.447Z
-    url: https://www.medrxiv.org/content/10.1101/2021.04.14.21255512v1.full.pdf
-    description: A study from our team finding that life expectancy among people
-      incarcerated in Florida state prisons has dropped by more than four years,
-      from 77.9 to 73.8 years, during the COVID-19 pandemic.
-    title: Assessing the Mortality Impact of the COVID-19 Pandemic in Florida State
-      Prison
-    author: medRxiv
 sponsors:
   title: "Our generous supporters include:"
 ---

--- a/packages/gatsby-ucla-site/content/pages/index.mdx
+++ b/packages/gatsby-ucla-site/content/pages/index.mdx
@@ -25,6 +25,23 @@ table:
 vaccineTable:
   title: COVID-19 Vaccines in Carceral Facilities
   subtitle: (set vaccine_subtitle in en.json used instead for markup)
+reports:
+  - date: 2020-07-08T20:04:00.559Z
+    description: A study using our data finding that, from March to June, 2020, the
+      COVID-19 case rate for incarcerated people was 5.5 times higher than the
+      overall US population case rate. Their age-adjusted death rate was 3.0
+      times higher.
+    url: https://jamanetwork.com/journals/jama/fullarticle/2768249
+    author: JAMA Network
+    title: COVID-19 Cases and Deaths in Federal and State Prisons
+  - date: 2021-04-20T20:04:24.447Z
+    url: https://www.medrxiv.org/content/10.1101/2021.04.14.21255512v1.full.pdf
+    description: A study from our team finding that life expectancy among people
+      incarcerated in Florida state prisons has dropped by more than four years,
+      from 77.9 to 73.8 years, during the COVID-19 pandemic.
+    title: Assessing the Mortality Impact of the COVID-19 Pandemic in Florida State
+      Prison
+    author: medRxiv
 sponsors:
   title: "Our generous supporters include:"
 ---

--- a/packages/gatsby-ucla-site/content/pages/reports.mdx
+++ b/packages/gatsby-ucla-site/content/pages/reports.mdx
@@ -2,7 +2,7 @@
 title: Reports
 path: /reports
 pagetype: reports
-reports:
+reportsData:
   - date: 2020-07-08T20:04:00.559Z
     description: A study using our data finding that, from March to June, 2020, the
       COVID-19 case rate for incarcerated people was 5.5 times higher than the

--- a/packages/gatsby-ucla-site/content/pages/reports.mdx
+++ b/packages/gatsby-ucla-site/content/pages/reports.mdx
@@ -2,7 +2,7 @@
 title: Reports
 path: /reports
 pagetype: reports
-reportes:
+reports:
   - date: 2020-07-08T20:04:00.559Z
     description: A study using our data finding that, from March to June, 2020, the
       COVID-19 case rate for incarcerated people was 5.5 times higher than the

--- a/packages/gatsby-ucla-site/content/pages/reports.mdx
+++ b/packages/gatsby-ucla-site/content/pages/reports.mdx
@@ -1,0 +1,31 @@
+---
+title: Reports
+path: /reports
+pagetype: reports
+reportes:
+  - date: 2020-07-08T20:04:00.559Z
+    description: A study using our data finding that, from March to June, 2020, the
+      COVID-19 case rate for incarcerated people was 5.5 times higher than the
+      overall US population case rate. Their age-adjusted death rate was 3.0
+      times higher.
+    url: https://jamanetwork.com/journals/jama/fullarticle/2768249
+    author: JAMA Network
+    title: COVID-19 Cases and Deaths in Federal and State Prisons
+  - date: 2021-04-20T20:04:24.447Z
+    url: https://www.medrxiv.org/content/10.1101/2021.04.14.21255512v1.full.pdf
+    description: A study from our team finding that life expectancy among people
+      incarcerated in Florida state prisons has dropped by more than four years,
+      from 77.9 to 73.8 years, during the COVID-19 pandemic.
+    title: Assessing the Mortality Impact of the COVID-19 Pandemic in Florida State
+      Prison
+    author: medRxiv
+---
+
+import ReportList from "../../src/components/reports/ReportList"
+
+## Reports
+
+<ReportList />
+
+&nbsp;\
+&nbsp;

--- a/packages/gatsby-ucla-site/content/pages/resources.mdx
+++ b/packages/gatsby-ucla-site/content/pages/resources.mdx
@@ -9,3 +9,6 @@ import ResourceList from "../../src/components/resources/ResourceList"
 ## Resources
 
 <ResourceList />
+
+&nbsp;\
+&nbsp;

--- a/packages/gatsby-ucla-site/src/components/reports/ReportList.js
+++ b/packages/gatsby-ucla-site/src/components/reports/ReportList.js
@@ -14,6 +14,9 @@ const useStyles = makeStyles((theme) => ({
   details: {
     display: "inline",
   },
+  primary: {
+    marginBottom: theme.spacing(0.5),
+  },
 }))
 
 const ReportTitle = ({ report }) => {
@@ -33,6 +36,7 @@ const ReportTitle = ({ report }) => {
 
 const ReportList = (props) => {
   const reports = useReportsData()
+  const classes = useStyles()
 
   return (
     <List>
@@ -41,6 +45,7 @@ const ReportList = (props) => {
           <ListItemText
             primary={<ReportTitle report={report} />}
             secondary={report.description}
+            classes={{ primary: classes.primary }}
           />
         </ListItem>
       ))}

--- a/packages/gatsby-ucla-site/src/components/reports/ReportList.js
+++ b/packages/gatsby-ucla-site/src/components/reports/ReportList.js
@@ -1,0 +1,53 @@
+import React from "react"
+import useReportsData from "./useReportsData"
+import {
+  Link,
+  List,
+  ListItem,
+  ListItemText,
+  Typography,
+  makeStyles,
+} from "@material-ui/core"
+import moment from "moment"
+
+const useStyles = makeStyles((theme) => ({
+  details: {
+    display: "inline",
+  },
+}))
+
+const ReportTitle = ({ report }) => {
+  const classes = useStyles()
+
+  return (
+    <>
+      <Link target="_blank" href={report.url}>
+        {report.title}
+      </Link>{" "}
+      <Typography variant="body2" className={classes.details}>
+        {moment(report.date).format("MMMM Do, YYYY")}, {report.author}
+      </Typography>
+    </>
+  )
+}
+
+const ReportList = (props) => {
+  const reports = useReportsData()
+
+  return (
+    <List>
+      {reports.map((report) => (
+        <ListItem>
+          <ListItemText
+            primary={<ReportTitle report={report} />}
+            secondary={report.description}
+          />
+        </ListItem>
+      ))}
+    </List>
+  )
+}
+
+ReportList.propTypes = {}
+
+export default ReportList

--- a/packages/gatsby-ucla-site/src/components/reports/useReportsData.js
+++ b/packages/gatsby-ucla-site/src/components/reports/useReportsData.js
@@ -1,0 +1,24 @@
+import { useStaticQuery, graphql } from "gatsby"
+
+export default function useResourcesData() {
+  const { allMdx } = useStaticQuery(
+    graphql`
+      query {
+        allMdx(filter: { slug: { eq: "reports" } }) {
+          nodes {
+            frontmatter {
+              reportes {
+                date
+                description
+                url
+                author
+                title
+              }
+            }
+          }
+        }
+      }
+    `
+  )
+  return allMdx.nodes[0].frontmatter.reportes
+}

--- a/packages/gatsby-ucla-site/src/components/reports/useReportsData.js
+++ b/packages/gatsby-ucla-site/src/components/reports/useReportsData.js
@@ -7,7 +7,7 @@ export default function useResourcesData() {
         allMdx(filter: { slug: { eq: "reports" } }) {
           nodes {
             frontmatter {
-              reportes {
+              reports {
                 date
                 description
                 url
@@ -20,5 +20,5 @@ export default function useResourcesData() {
       }
     `
   )
-  return allMdx.nodes[0].frontmatter.reportes
+  return allMdx.nodes[0].frontmatter.reports
 }

--- a/packages/gatsby-ucla-site/src/components/reports/useReportsData.js
+++ b/packages/gatsby-ucla-site/src/components/reports/useReportsData.js
@@ -7,7 +7,7 @@ export default function useResourcesData() {
         allMdx(filter: { slug: { eq: "reports" } }) {
           nodes {
             frontmatter {
-              reports {
+              reportsData {
                 date
                 description
                 url
@@ -20,5 +20,5 @@ export default function useResourcesData() {
       }
     `
   )
-  return allMdx.nodes[0].frontmatter.reports
+  return allMdx.nodes[0].frontmatter.reportsData
 }

--- a/packages/gatsby-ucla-site/src/components/resources/ResourceList.js
+++ b/packages/gatsby-ucla-site/src/components/resources/ResourceList.js
@@ -42,7 +42,7 @@ const ResourceDescription = ({ resource, ...props }) => {
 
 const ResourceList = (props) => {
   const data = useResourcesData()
-  const resources = data.map((category) => (
+  return data.map((category) => (
     <>
       <Typography variant="h3">{category.fieldValue}</Typography>
       <List>
@@ -57,38 +57,6 @@ const ResourceList = (props) => {
       </List>
     </>
   ))
-
-  // NOTE - just a stopgap until there is a Reports page
-  const reportsData = [
-    {
-      organization: "COVID-19 Cases and Deaths in Federal and State Prisons",
-      description: "JAMA Network Report",
-      links: ["https://jamanetwork.com/journals/jama/fullarticle/2768249"],
-    },
-  ]
-
-  const reports = (
-    <>
-      <Typography variant="h2">Reports</Typography>
-      <List>
-        {reportsData.map((resource) => (
-          <ListItem>
-            <ListItemText
-              primary={<ResourceTitle resource={resource} />}
-              secondary={<ResourceDescription resource={resource} />}
-            />
-          </ListItem>
-        ))}
-      </List>
-    </>
-  )
-
-  return (
-    <>
-      {resources}
-      {reports}
-    </>
-  )
 }
 
 ResourceList.propTypes = {}

--- a/packages/gatsby-ucla-site/src/components/states/JurisdictionStatList.js
+++ b/packages/gatsby-ucla-site/src/components/states/JurisdictionStatList.js
@@ -54,20 +54,18 @@ const styles = (theme) => ({
       ...sansSerifyTypography,
       fontSize: theme.typography.pxToRem(16),
       color: theme.palette.text.primary,
+      "&:visited": {
+        color: theme.palette.text.primary,
+      },
       textDecoration: "underline",
       "&:hover": {
         textDecorationColor: theme.palette.secondary.main,
-      },
-
-      "& .MuiSvgIcon-root": {
-        fontSize: theme.typography.pxToRem(16),
-        marginTop: "auto",
-        marginBottom: "auto",
       },
     },
   },
   tooltip: {
     color: "#fff",
+    fontSize: theme.typography.pxToRem(12),
   },
 })
 
@@ -110,13 +108,13 @@ const JurisdictionStatList = ({
       state: [stateScore, "#scorecard", "state"],
       immigration: [iceScore, "/ice#scorecard", "ICE"],
       federal: isFederal
-        ? [stateScore, "#scorecard", "federal"]
-        : [fedScore, "/federal#scorecard", "federal"],
+        ? [stateScore, "#scorecard", "BOP"]
+        : [fedScore, "/federal#scorecard", "BOP"],
     }[jurisdiction]
 
     const title = (
       <Typography variant="body2" className={classes.tooltip}>
-        go to {name} scorecard
+        View {name} scorecard
       </Typography>
     )
     return (

--- a/packages/gatsby-ucla-site/src/gatsby-theme-hyperobjekt-core/theme.js
+++ b/packages/gatsby-ucla-site/src/gatsby-theme-hyperobjekt-core/theme.js
@@ -191,7 +191,7 @@ const CovidTheme = () => {
       MuiTooltip: {
         tooltip: {
           backgroundColor: fade(theme.palette.text.primary, 0.9),
-          padding: theme.spacing(2),
+          padding: theme.spacing(1),
           borderRadius: 4,
         },
         arrow: {

--- a/packages/gatsby-ucla-site/static/admin/config.yml
+++ b/packages/gatsby-ucla-site/static/admin/config.yml
@@ -59,8 +59,9 @@ collections:
           hint: "Image used when page is shared on social media",
         }
       - { label: "Body", name: "body", widget: "markdown" }
-  - label: "Reports"
+  - label: "Reports Page"
     name: "reports"
+    identifier_field: name
     extension: mdx
     format: frontmatter
     create: false
@@ -69,8 +70,8 @@ collections:
       preview: false
     filter: { field: "pagetype", value: "reports" }
     fields:
-      - label: "Reports"
-        name: reports
+      - label: "Reports Data"
+        name: reportsData
         widget: list
         allow_add: true
         fields:

--- a/packages/gatsby-ucla-site/static/admin/config.yml
+++ b/packages/gatsby-ucla-site/static/admin/config.yml
@@ -1,9 +1,9 @@
-# backend:
-#   name: git-gateway
-#   repo: Hyperobjekt/covid-19-behind-bars
-#   branch: production
+backend:
+  name: git-gateway
+  repo: Hyperobjekt/covid-19-behind-bars
+  branch: production
 
-# publish_mode: editorial_workflow
+publish_mode: editorial_workflow
 
 # FOR LOCAL DEVELOPMENT:
 # ---
@@ -11,10 +11,10 @@
 # - uncomment the backend below
 # - run `npx netlify-cms-proxy-server` to serve content
 
-backend:
-  name: proxy
-  proxy_url: http://localhost:8081/api/v1
-  branch: cms # optional, defaults to master
+# backend:
+#   name: proxy
+#   proxy_url: http://localhost:8081/api/v1
+#   branch: cms # optional, defaults to master
 
 media_folder: /packages/gatsby-ucla-site/content/assets
 public_folder: /packages/gatsby-ucla-site/assets
@@ -69,8 +69,8 @@ collections:
       preview: false
     filter: { field: "pagetype", value: "reports" }
     fields:
-      - label: "Reportes"
-        name: reportes
+      - label: "Reports"
+        name: reports
         widget: list
         allow_add: true
         fields:

--- a/packages/gatsby-ucla-site/static/admin/config.yml
+++ b/packages/gatsby-ucla-site/static/admin/config.yml
@@ -59,6 +59,26 @@ collections:
           hint: "Image used when page is shared on social media",
         }
       - { label: "Body", name: "body", widget: "markdown" }
+  - label: "Reports"
+    name: "reports"
+    extension: mdx
+    format: frontmatter
+    create: false
+    folder: "/packages/gatsby-ucla-site/content/pages"
+    editor:
+      preview: false
+    filter: { field: "pagetype", value: "reports" }
+    fields:
+      - label: "Reportes"
+        name: reportes
+        widget: list
+        allow_add: true
+        fields:
+          - { label: "Title", name: "title", widget: "string", required: true }
+          - { label: "Date", name: "date", widget: "date", required: true }
+          - { label: "Author", name: "author", widget: "string", required: true }
+          - { label: "Description", name: "description", widget: "text", required: true }
+          - { label: "URL", name: "url", widget: "string", required: true }
   - label: "Home Page"
     name: "homepage"
     extension: mdx
@@ -128,16 +148,6 @@ collections:
         fields:
           - { label: Title, name: title, widget: markdown, required: false }
           - name: "blog"
-      - label: "Reports"
-        name: reports
-        widget: list
-        allow_add: true
-        fields:
-          - { label: "Title", name: "title", widget: "string", required: true }
-          - { label: "Date", name: "date", widget: "date", required: true }
-          - { label: "Author", name: "author", widget: "string", required: true }
-          - { label: "Description", name: "description", widget: "text", required: true }
-          - { label: "URL", name: "url", widget: "string", required: true }
   - label: "Blog post"
     folder: "/packages/gatsby-ucla-site/content/pages/blog"
     name: "blogpost"

--- a/packages/gatsby-ucla-site/static/admin/config.yml
+++ b/packages/gatsby-ucla-site/static/admin/config.yml
@@ -1,19 +1,20 @@
-backend:
-  name: git-gateway
-  repo: Hyperobjekt/covid-19-behind-bars
-  branch: production
+# backend:
+#   name: git-gateway
+#   repo: Hyperobjekt/covid-19-behind-bars
+#   branch: production
 
-publish_mode: editorial_workflow
+# publish_mode: editorial_workflow
 
 # FOR LOCAL DEVELOPMENT:
 # ---
+# - comment the above (*including* publish_mode)
 # - uncomment the backend below
 # - run `npx netlify-cms-proxy-server` to serve content
 
-# backend:
-#   name: proxy
-#   proxy_url: http://localhost:8081/api/v1
-#   branch: cms # optional, defaults to master
+backend:
+  name: proxy
+  proxy_url: http://localhost:8081/api/v1
+  branch: cms # optional, defaults to master
 
 media_folder: /packages/gatsby-ucla-site/content/assets
 public_folder: /packages/gatsby-ucla-site/assets
@@ -127,6 +128,16 @@ collections:
         fields:
           - { label: Title, name: title, widget: markdown, required: false }
           - name: "blog"
+      - label: "Reports"
+        name: reports
+        widget: list
+        allow_add: true
+        fields:
+          - { label: "Title", name: "title", widget: "string", required: true }
+          - { label: "Date", name: "date", widget: "date", required: true }
+          - { label: "Author", name: "author", widget: "string", required: true }
+          - { label: "Description", name: "description", widget: "text", required: true }
+          - { label: "URL", name: "url", widget: "string", required: true }
   - label: "Blog post"
     folder: "/packages/gatsby-ucla-site/content/pages/blog"
     name: "blogpost"


### PR DESCRIPTION
Everything is working as it should _except_ something is slightly wonky with the config.yml that is failing to locate the reports in the CMS... Maybe from a misalignment between a label/name/title value for reports? It was working locally and everything was appearing as it should, but something changed and I can't seem to get back to that state (not sure if it's a caching thing, because that's constantly giving me trouble with Gatsby). @Lane if it's not clear to you what's wrong I can keep debugging in the morning.

Liz approved moving Reports to their own page.

closes #320 and closes #321