### PR TITLE
pull from May Sheet tab

### DIFF
--- a/packages/gatsby-ucla-site/content/federal.json
+++ b/packages/gatsby-ucla-site/content/federal.json
@@ -69,11 +69,13 @@
           "deaths_residents": "Cumulative Deaths",
           "active_residents": "Active Cases",
           "tests_residents": "Tests Administered",
-          "population_residents": "Total Population",
+          "population_residents": "Population",
           "vaccinations_residents": "Vaccinations",
           "cases_staff": "Cumulative Cases",
           "deaths_staff": "Cumulative Deaths",
+          "active_staff": "Active Cases",
           "tests_staff": "Tests Administered",
+          "population_staff": "Population",
           "vaccinations_staff": "Vaccinations"
         },
         "table_value": {

--- a/packages/gatsby-ucla-site/content/immigration.json
+++ b/packages/gatsby-ucla-site/content/immigration.json
@@ -23,11 +23,13 @@
         "deaths_residents": "Cumulative Deaths",
         "active_residents": "Active Cases",
         "tests_residents": "Tests Administered",
-        "population_residents": "Total Population",
+        "population_residents": "Population",
         "vaccinations_residents": "Vaccinations",
         "cases_staff": "Cumulative Cases",
         "deaths_staff": "Cumulative Deaths",
+        "active_staff": "Active Cases",
         "tests_staff": "Tests Administered",
+        "population_staff": "Population",
         "vaccinations_staff": "Vaccinations"
       },
       "table_value": {

--- a/packages/gatsby-ucla-site/content/states.json
+++ b/packages/gatsby-ucla-site/content/states.json
@@ -76,11 +76,13 @@
           "deaths_residents": "Cumulative Deaths",
           "active_residents": "Active Cases",
           "tests_residents": "Tests Administered",
-          "population_residents": "Total Population",
+          "population_residents": "Population",
           "vaccinations_residents": "Vaccinations",
           "cases_staff": "Cumulative Cases",
           "deaths_staff": "Cumulative Deaths",
+          "active_staff": "Active Cases",
           "tests_staff": "Tests Administered",
+          "population_staff": "Population",
           "vaccinations_staff": "Vaccinations"
         },
         "table_value": {

--- a/packages/gatsby-ucla-site/scripts/fetchData.js
+++ b/packages/gatsby-ucla-site/scripts/fetchData.js
@@ -45,7 +45,7 @@ exports.getVaccines = () => getData(vaccinesCsv, parseVaccine)
  * sheet has hidden top row with stable, machine-readable names
  */
 
-const scorecard = `https://docs.google.com/spreadsheets/d/1fHhRAjwYGVmgoHLUENvcYffHDjEQnpp7Rwt9tLeX_Xk/export?gid=0&format=csv`
+const scorecard = `https://docs.google.com/spreadsheets/d/1fHhRAjwYGVmgoHLUENvcYffHDjEQnpp7Rwt9tLeX_Xk/export?gid=696812429&format=csv`
 
 const scorecardMap = {
   state: ["state", "string", exactMatch],
@@ -65,6 +65,8 @@ const scorecardMap = {
   deaths_staff: ["deaths_staff", "string", exactMatch],
   tests_staff: ["tests_staff", "string", exactMatch],
   vaccinations_staff: ["vaccinations_staff", "string", exactMatch],
+  active_staff: ["active_staff", "string", exactMatch],
+  population_staff: ["population_staff", "string", exactMatch],
 }
 
 const scorecardParser = (row) => parseMap(row, scorecardMap)

--- a/packages/gatsby-ucla-site/src/components/immigration/immigration.js
+++ b/packages/gatsby-ucla-site/src/components/immigration/immigration.js
@@ -61,6 +61,8 @@ export const query = graphql`
         deaths_staff
         tests_staff
         vaccinations_staff
+        active_staff
+        population_staff
       }
     }
   }

--- a/packages/gatsby-ucla-site/src/components/states/Federal.js
+++ b/packages/gatsby-ucla-site/src/components/states/Federal.js
@@ -253,6 +253,8 @@ export const query = graphql`
         deaths_staff
         tests_staff
         vaccinations_staff
+        active_staff
+        population_staff
       }
     }
   }

--- a/packages/gatsby-ucla-site/src/components/states/sections/Scorecard.js
+++ b/packages/gatsby-ucla-site/src/components/states/sections/Scorecard.js
@@ -225,7 +225,9 @@ const resReportingColumns = [
 const staffReportingColumns = [
   { id: "cases_staff" },
   { id: "deaths_staff" },
+  { id: "active_staff" },
   { id: "tests_staff" },
+  { id: "population_staff" },
   { id: "vaccinations_staff" },
 ]
 

--- a/packages/gatsby-ucla-site/src/components/states/states.js
+++ b/packages/gatsby-ucla-site/src/components/states/states.js
@@ -305,6 +305,8 @@ export const query = graphql`
         deaths_staff
         tests_staff
         vaccinations_staff
+        active_staff
+        population_staff
       }
     }
     fedScorecard: allScorecard(filter: { state: { eq: "Federal (BOP)" } }) {


### PR DESCRIPTION
add "active cases" and "population" to staff scorecard
rename "total population" to "population"

closes #333 