### PR TITLE
set grassroots & releases tables column widths

### DIFF
--- a/packages/gatsby-ucla-site/content/states.json
+++ b/packages/gatsby-ucla-site/content/states.json
@@ -127,7 +127,7 @@
           "facility": "Facility/facilities",
           "authority": "Authorizing agent(s)",
           "date": "Date*",
-          "releases": "Overall population reduction/total number of releases**",
+          "releases": "Overall population reduction/ total # of releases**",
           "population": "Population prior to releases***",
           "proportion": "Releases as percentage of population",
           "capacity": "Known facility capacity****",
@@ -170,7 +170,7 @@
           "county": "County",
           "organization": "Organization",
           "type": "Type of effort",
-          "effort": "Internal or external",
+          "effort": "Internal/ external",
           "effortMap": {
             "external_effort": "Internal",
             "internal_effort": "External",

--- a/packages/gatsby-ucla-site/src/components/states/sections/GrassrootsTable.js
+++ b/packages/gatsby-ucla-site/src/components/states/sections/GrassrootsTable.js
@@ -31,11 +31,18 @@ const GrassrootsTable = ({ classes, data, lang, ...props }) => {
         Header: lang.table.facility,
         accessor: "facility",
         Cell: (prop) => prop.value,
+        style: {
+          width: "12%",
+          minWidth: "7.2rem",
+        },
       },
       {
         Header: lang.table.county,
         accessor: "county",
         Cell: (prop) => prop.value,
+        style: {
+          width: "12%",
+        },
       },
       {
         Header: lang.table.date,
@@ -43,27 +50,45 @@ const GrassrootsTable = ({ classes, data, lang, ...props }) => {
         Cell: (prop) => prop.value,
         style: {
           textAlign: "right",
+          width: "12%",
+          minWidth: "7.3rem",
         },
       },
       {
         Header: lang.table.organization,
         accessor: "organization",
         Cell: (prop) => prop.value,
+        style: {
+          width: "25%",
+          minWidth: "8rem",
+        },
       },
       {
         Header: lang.table.type,
         accessor: "type",
         Cell: (prop) => prop.value,
+        style: {
+          minWidth: "7.1rem",
+          maxWidth: "7.1rem",
+        },
       },
       {
         Header: lang.table.effort,
         accessor: "effort",
         Cell: (prop) => prop.value,
+        style: {
+          minWidth: "5rem",
+          maxWidth: "5rem",
+        },
       },
       {
         Header: lang.table.concerns,
         accessor: "concerns",
         Cell: (prop) => prop.value,
+        style: {
+          minWidth: "8rem",
+          maxWidth: "8rem",
+        },
       },
       {
         Header: lang.table.source,
@@ -72,14 +97,14 @@ const GrassrootsTable = ({ classes, data, lang, ...props }) => {
           if (!value) return " "
           // const trunc = value.length < 35 ? value : value.slice(0, 31) + "..."
           return (
-            <a
-              title={value}
-              href={value}
-              target="__blank"
-            >
+            <a title={value} href={value} target="__blank">
               <LinkIcon />
             </a>
           )
+        },
+        style: {
+          minWidth: "4rem",
+          maxWidth: "4rem",
         },
       },
     ],

--- a/packages/gatsby-ucla-site/src/components/states/sections/ReleasesTable.js
+++ b/packages/gatsby-ucla-site/src/components/states/sections/ReleasesTable.js
@@ -39,17 +39,19 @@ const ReleasesTable = ({
         Header: lang.table.jurisdiction,
         accessor: "jurisdiction",
         Cell: (prop) => prop.value,
-        // style: { minWidth: "50%" },
+        style: { width: "12%" },
       },
       {
         Header: lang.table.facility,
         accessor: "facility",
         Cell: (prop) => prop.value,
+        style: { width: "11%" },
       },
       {
         Header: lang.table.authority,
         accessor: "authority",
         Cell: (prop) => prop.value,
+        style: { width: "10%" },
       },
       {
         Header: lang.table.date,
@@ -57,6 +59,7 @@ const ReleasesTable = ({
         Cell: (prop) => prop.value,
         style: {
           textAlign: "right",
+          width: "10%",
         },
       },
       {
@@ -65,6 +68,8 @@ const ReleasesTable = ({
         Cell: (prop) => prop.value,
         style: {
           textAlign: "right",
+          minWidth: "8rem",
+          maxWidth: "8rem",
         },
       },
       {
@@ -73,6 +78,7 @@ const ReleasesTable = ({
         Cell: (prop) => prop.value,
         style: {
           textAlign: "right",
+          width: "13%",
         },
       },
       {
@@ -81,12 +87,17 @@ const ReleasesTable = ({
         Cell: (prop) => prop.value,
         style: {
           textAlign: "right",
+          width: "13%",
         },
       },
       {
         Header: lang.table.details,
         accessor: "details",
         Cell: (prop) => prop.value,
+        style: {
+          width: "14%",
+          minWidth: "7.8rem",
+        },
       },
       {
         Header: lang.table.source,
@@ -99,6 +110,10 @@ const ReleasesTable = ({
               <LinkIcon />
             </a>
           )
+        },
+        style: {
+          minWidth: "4rem",
+          maxWidth: "4rem",
         },
       },
     ],


### PR DESCRIPTION
Feels a bit hard-coded, but does improve the UX a bit. Column widths can still adjust a bit on sort, when a long word in a table cell causes a column to grow to prevent the word from breaking in the middle -- which can also create a horizontal scroll bar. I tried to prevent the more notable jumpiness by ensuring the table headers don't change how many lines they span over between sorts (making the table header grow & shrink); this is obviously a bit hard-coded since those titles could change (I also made a couple of verbiage tweaks we'd need to get approval for). If we're okay with a horizontal scroll earlier we could be more generous in the spacing.

closes #239