### PR TITLE
refactor blog components, update blog styles

### DIFF
--- a/content/pages/publications-and-resources/blog/missing-the-mark-introducing-our-carceral-agency-scorecard.mdx
+++ b/content/pages/publications-and-resources/blog/missing-the-mark-introducing-our-carceral-agency-scorecard.mdx
@@ -32,9 +32,12 @@ Agencies also report data in formats that are hard to access or analyze. In some
 
 To demonstrate these inconsistencies in data reporting and quality, we have created a scorecard to assess each of the 53 major state and federal agencies according to a number of metrics related to what COVID-19 data they report (our data reporting metrics) and how they report those data (our data quality metrics).
 
+<figure>
+
 ![Data Reporting & Quality Scorecard for the California Department of Corrections and Rehabilitation](images/screen-shot-2021-03-16-at-9.41.56-pm.png "Data Reporting & Quality Scorecard for the California Department of Corrections and Rehabilitation")
 
-<i>Scorecard for the California Department of Corrections and Rehabilitation</i>
+<figcaption>Scorecard for the California Department of Corrections and Rehabilitation</figcaption>
+</figure>
 
 We assigned our first round of scores and grades on March 15, 2021. Of the 53 systems assessed, the highest grade was a B for the West Virginia Division of Corrections and Rehabilitation. The state correctional agencies in California, Indiana, Minnesota, North Carolina, Oregon, and Wisconsin received a grade of C, and the agencies in Colorado, Maryland, Michigan, and North Dakota, as well as the BOP, received a D. The other 41 — more than 75% of agencies — failed.
 

--- a/content/pages/publications-and-resources/blog/prison-law-office.mdx
+++ b/content/pages/publications-and-resources/blog/prison-law-office.mdx
@@ -102,13 +102,12 @@ Still, the tragedy is wide-reaching and ongoing. And while it’s an epidemiolog
 
 <figure>
 
-![Photograph of Joshua Hall](images/joshua-hall-photo.png)
+![Photograph of Joshua Hall](./images/joshua-hall-photo.png)
 
 <figcaption>
-  Joshua Hall, an overcrowded unit where people with disabilities have been
-  incarcerated in close quarters and unable to social distance.
+Joshua Hall, an overcrowded unit where people with disabilities have been
+incarcerated in close quarters and unable to social distance.
 </figcaption>
-
 </figure>
 
 At the same time, Lomio said, despite demands from public health experts, the state of California has not released people on the scale necessary to prevent spread in state facilities.

--- a/content/pages/publications-and-resources/blog/update-data-reporting-quality-scorecard.mdx
+++ b/content/pages/publications-and-resources/blog/update-data-reporting-quality-scorecard.mdx
@@ -42,9 +42,12 @@ Grades for the state correctional agencies in Indiana, North Carolina, and Orego
 
 We once again note that the scores we have assigned to the agencies do not reflect our judgment on how each has managed and responded to COVID-19 inside prisons, nor how reliably we believe the reported data correspond to true facts on the ground. They only reflect  our judgments on how comprehensive the data are and how well they are presented.
 
+<figure>
+
 ![Data Reporting & Quality Scorecard for the California Department of Corrections and Rehabilitation](images/screen-shot-2021-04-16-at-1.21.04-pm.png "Data Reporting & Quality Scorecard for the California Department of Corrections and Rehabilitation")
 
-<i>Scorecard for the California Department of Corrections and Rehabilitation</i>
+<figcaption>Scorecard for the California Department of Corrections and Rehabilitation</figcaption>
+</figure>
 
 ### **About the Metrics**
 

--- a/src/components/Figure.js
+++ b/src/components/Figure.js
@@ -1,0 +1,19 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { StaticImage } from "gatsby-plugin-image";
+
+const Figure = ({ src, alt, children, ...props }) => {
+  return (
+    <figure {...props}>
+      <StaticImage src="/images/joshua-hall-photo.png" alt={alt} />
+      {children && <figcaption>{children}</figcaption>}
+    </figure>
+  );
+};
+
+Figure.propTypes = {
+  src: PropTypes.string,
+  alt: PropTypes.string,
+};
+
+export default Figure;

--- a/src/components/blog/hero.js
+++ b/src/components/blog/hero.js
@@ -1,0 +1,45 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { withStyles } from "@material-ui/core";
+import { compactTitleTypography } from "../../gatsby-theme-hypercore/theme";
+import moment from "moment";
+import Block from "gatsby-theme-hypersite/src/main/block";
+
+const styles = (theme) => ({
+  hero: {
+    [theme.breakpoints.up("md")]: {
+      paddingRight: theme.columnSpacing(2),
+    },
+  },
+  date: {
+    fontSize: theme.typography.pxToRem(14),
+  },
+  postTitle: {
+    ...compactTitleTypography,
+    color: theme.palette.text.secondary,
+    lineHeight: 1.05,
+    margin: 0,
+    paddingBottom: theme.spacing(5),
+    fontSize: theme.typography.pxToRem(55),
+    [theme.breakpoints.up("sm")]: {
+      fontSize: theme.typography.pxToRem(70),
+    },
+    [theme.breakpoints.up("md")]: {
+      fontSize: theme.typography.pxToRem(85),
+    },
+  },
+});
+
+const Hero = ({ classes, author, date, title, ...props }) => {
+  const postDetails = `${author} • ${moment(date).format("MMMM Do, YYYY")}`;
+  return (
+    <Block>
+      <div className={classes.hero} {...props}>
+        <p className={classes.date}>{postDetails}</p>
+        <h2 className={classes.postTitle}>{title}</h2>
+      </div>
+    </Block>
+  );
+};
+
+export default withStyles(styles)(Hero);

--- a/src/components/blog/index.js
+++ b/src/components/blog/index.js
@@ -1,3 +1,6 @@
 export { default as BlogFeatured } from "./blog-featured";
 export { default as BlogPost } from "./blog-post";
 export { default as BlogPosts } from "./blog-posts";
+export { default as BlogHero } from "./hero";
+export { default as BlogSocialLinks } from "./social-links";
+export { default as BlogLinkedPost } from "./linked-post";

--- a/src/components/blog/linked-post.js
+++ b/src/components/blog/linked-post.js
@@ -1,0 +1,82 @@
+import React from "react";
+import { Link } from "gatsby-theme-material-ui";
+import { withStyles } from "@material-ui/core";
+import {
+  serifTypography,
+  subtitleTypography,
+} from "../../gatsby-theme-hypercore/theme";
+
+const styles = (theme) => ({
+  linkedSection: {},
+  sectionTitle: {
+    ...subtitleTypography,
+    color: theme.palette.secondary.main,
+    fontSize: theme.typography.pxToRem(28),
+    letterSpacing: 18 / 25,
+  },
+  linkedTitle: {
+    ...serifTypography,
+    fontWeight: 400,
+    color: theme.palette.text.primary,
+    fontSize: theme.typography.pxToRem(32),
+    lineHeight: 1.25,
+    margin: 0,
+    maxWidth: theme.columnSpacing(10),
+    [theme.breakpoints.up("sm")]: {
+      maxWidth: theme.columnSpacing(8),
+    },
+    [theme.breakpoints.up("md")]: {
+      maxWidth: theme.columnSpacing(6),
+    },
+  },
+  description: {
+    ...serifTypography,
+    color: theme.palette.text.primary,
+    fontSize: theme.typography.pxToRem(16),
+    lineHeight: 1.5,
+    marginTop: theme.spacing(2),
+    marginBottom: theme.spacing(3),
+    maxWidth: theme.columnSpacing(9),
+    [theme.breakpoints.up("sm")]: {
+      maxWidth: theme.columnSpacing(7),
+    },
+    [theme.breakpoints.up("md")]: {
+      maxWidth: theme.columnSpacing(5),
+    },
+  },
+  readLink: {
+    "&:not(:hover)": {
+      color: `${theme.palette.text.primary} !important`,
+    },
+    textDecoration: "none !important",
+    paddingBottom: theme.spacing(1),
+    borderBottom: "solid 1px",
+    borderBottomColor: theme.palette.secondary.main,
+    marginBottom: theme.spacing(3),
+    display: "inline-block",
+  },
+});
+
+const Linked = ({ classes, next, previous }) => {
+  const post = next || previous;
+  if (!post) {
+    return null;
+  }
+  const { title, description, path } = post.frontmatter;
+  const sectionTitle = (next ? "next" : "previous") + " post";
+  return (
+    <div className={classes.linkedSection}>
+      <div className={classes.post}>
+        <h3 className={classes.sectionTitle}>{sectionTitle}</h3>
+        <h4 className={classes.linkedTitle}>{title}</h4>
+        <p className={classes.description}>{description}</p>
+
+        <Link className={classes.readLink} to={"/" + path}>
+          Read more
+        </Link>
+      </div>
+    </div>
+  );
+};
+
+export default withStyles(styles)(Linked);

--- a/src/components/blog/social-links.js
+++ b/src/components/blog/social-links.js
@@ -1,0 +1,86 @@
+import React from "react";
+import FbIcon from "../../common/icons/fb-icon.svg";
+import TwitterIcon from "@material-ui/icons/Twitter";
+import EmailIcon from "@material-ui/icons/Email";
+import IconButton from "@material-ui/core/IconButton";
+import { useLocation } from "@reach/router";
+import { withStyles } from "@material-ui/core";
+
+const styles = (theme) => ({
+  social: {
+    display: "flex",
+    margin: "auto",
+    marginBottom: theme.spacing(3),
+    "& button": {
+      background: theme.palette.background.alt2,
+      color: theme.palette.text.secondary,
+      padding: "10px",
+      marginRight: theme.spacing(1),
+      "& a": {
+        color: theme.palette.text.secondary + "!important",
+        fontSize: "0",
+      },
+      [theme.breakpoints.down("xs")]: {
+        marginRight: "0",
+        transform: "scale(0.8)",
+      },
+    },
+    [theme.breakpoints.up("lg")]: {
+      flexDirection: "column",
+      position: "absolute",
+      left: theme.spacing(6),
+      top: 0,
+      "& button": {
+        padding: "12px",
+        marginBottom: theme.spacing(1),
+      },
+    },
+  },
+});
+
+const SocialLinks = ({ classes, title }) => {
+  const location = useLocation();
+  const url = "https://uclacovidbehindbars.org" + location.pathname;
+
+  const twitterClick = (e) => {
+    window
+      .open(
+        `https://twitter.com/share?text=${title}&url=${url}`,
+        "_blank",
+        "width=550,height=420"
+      )
+      .focus();
+  };
+
+  const facebookClick = (e) => {
+    window
+      .open(
+        `https://www.facebook.com/sharer/sharer.php?u=${url}`,
+        "_blank",
+        "width=550,height=420"
+      )
+      .focus();
+  };
+
+  return (
+    <div className={classes.social}>
+      <IconButton onClick={twitterClick}>
+        <TwitterIcon />
+      </IconButton>
+      <IconButton onClick={facebookClick}>
+        <img alt="share on Facebook" src={FbIcon} />
+      </IconButton>
+      <IconButton>
+        <a
+          target="_blank"
+          href={`mailto:?subject=${title} - UCLA COVID Behind Bars&body=${url}`}
+          rel="noreferrer"
+        >
+          <EmailIcon />
+        </a>
+      </IconButton>
+    </div>
+  );
+};
+
+export default withStyles(styles)(SocialLinks);

--- a/src/components/home/HomeMap.js
+++ b/src/components/home/HomeMap.js
@@ -1,18 +1,15 @@
 import React from "react";
 import clsx from "clsx";
 import PropTypes from "prop-types";
-import { Box, fade, Grid, Typography, withStyles } from "@material-ui/core";
+import { Box, Typography, withStyles } from "@material-ui/core";
 import { Block } from "@hyperobjekt/material-ui-website";
 import { NationalMap, MapLegend } from "../maps";
 import { navigate } from "gatsby";
 import { useMapStore } from "@hyperobjekt/svg-maps";
-import Stack from "../Stack";
-import { serifTypography } from "../../gatsby-theme-hypercore/theme";
 import { useActiveMetric, useMappableFacilities } from "../../common/hooks";
 import { getLang } from "../../common/utils/i18n";
 import MetricSelectionTitle from "../controls/MetricSelectionTitle";
 import { getSlug } from "../../common/utils/selectors";
-import { Container } from "@hyperobjekt/material-ui-website";
 
 const styles = (theme) => ({
   root: {
@@ -112,10 +109,8 @@ const HomeMap = ({
   };
 
   // MetricSelection includes region name in immigration map
-  const [metricSelectCols, legendCols] = isImmigration ? [9, 3] : [8, 4];
 
   const notes = getLang("map", "notes", isImmigration && "immigration");
-  console.log(data, metric);
   return (
     <Block data-tip="" className={clsx(classes.root, className)} {...props}>
       <Box className={classes.mapContent}>

--- a/src/components/mdx.js
+++ b/src/components/mdx.js
@@ -1,0 +1,17 @@
+import React from "react";
+import { Button, Box } from "@material-ui/core";
+import { Block, Container } from "@hyperobjekt/material-ui-website";
+import mdxComponents from "gatsby-theme-hypersite/src/gatsby-theme-hypercore/mdx";
+import Figure from "./Figure";
+import { Typography } from "@material-ui/core";
+const components = {
+  ...mdxComponents,
+  section: Container,
+  span: (props) => <Typography component="span" {...props} />,
+  Block,
+  Box,
+  Button,
+  Figure,
+};
+
+export default components;

--- a/src/components/states/sections/Facilities.js
+++ b/src/components/states/sections/Facilities.js
@@ -1,17 +1,17 @@
-import React from "react"
-import { GROUPS } from "../../../common/constants"
-import FacilitiesTable from "../FacilitiesTable"
-import MetricSelectionTitle from "../../controls/MetricSelectionTitle"
-import shallow from "zustand/shallow"
-import useStatesStore from "../useStatesStore"
-import { useActiveMetric, useFacilitiesData } from "../../../common/hooks"
-import StepWrapper from "./../StepWrapper"
+import React from "react";
+import { GROUPS } from "../../../common/constants";
+import FacilitiesTable from "../FacilitiesTable";
+import MetricSelectionTitle from "../../controls/MetricSelectionTitle";
+import shallow from "zustand/shallow";
+import useStatesStore from "../useStatesStore";
+import { useActiveMetric, useFacilitiesData } from "../../../common/hooks";
+import StepWrapper from "./../StepWrapper";
 
 const Facilities = ({ id, lang, data, isFederal, ...props }) => {
-  const all = useFacilitiesData()
+  const all = useFacilitiesData();
 
   // currently selected metric
-  const metric = useActiveMetric()
+  const metric = useActiveMetric();
 
   // pull facilities group from the state page store
   const [facilitiesGroup, setFacilitiesGroup, stateName] = useStatesStore(
@@ -21,33 +21,32 @@ const Facilities = ({ id, lang, data, isFederal, ...props }) => {
       state.stateName,
     ],
     shallow
-  )
+  );
 
-  const [sortCol, setSortCol] = React.useState(facilitiesGroup)
-  const [sortedByGroup, setSortedByGroup] = React.useState(true)
+  const [sortCol, setSortCol] = React.useState(facilitiesGroup);
+  const [sortedByGroup, setSortedByGroup] = React.useState(true);
 
   // get facilities for current state
   const facilities = isFederal
     ? all.filter((f) => f.jurisdiction === "federal")
-    : all.filter((f) => f.state === stateName)
+    : all.filter((f) => f.state === stateName);
 
   // handler for when table headers are clicked
   const handleFacilitiesGroupChange = React.useCallback(
     (col) => {
-      const group = col.split(".")[0]
-      const isGroup = group && GROUPS.indexOf(group) > -1
-      setSortedByGroup(isGroup)
+      const group = col.split(".")[0];
+      const isGroup = group && GROUPS.indexOf(group) > -1;
+      setSortedByGroup(isGroup);
 
       if (isGroup) {
-        setSortCol(group)
-        console.log(group, facilitiesGroup)
-        group !== facilitiesGroup && setFacilitiesGroup(group)
+        setSortCol(group);
+        group !== facilitiesGroup && setFacilitiesGroup(group);
       } else {
-        setSortCol(col)
+        setSortCol(col);
       }
     },
     [facilitiesGroup, setFacilitiesGroup]
-  )
+  );
   return (
     <div {...props}>
       <StepWrapper>
@@ -63,9 +62,9 @@ const Facilities = ({ id, lang, data, isFederal, ...props }) => {
         />
       </StepWrapper>
     </div>
-  )
-}
+  );
+};
 
-Facilities.propTypes = {}
+Facilities.propTypes = {};
 
-export default Facilities
+export default Facilities;

--- a/src/gatsby-theme-hypercore/mdx.js
+++ b/src/gatsby-theme-hypercore/mdx.js
@@ -1,0 +1,1 @@
+export { default } from "../components/mdx";

--- a/src/gatsby-theme-hypercore/theme.js
+++ b/src/gatsby-theme-hypercore/theme.js
@@ -3,6 +3,12 @@ import { deepmerge } from "@material-ui/utils";
 import { fade as alpha, fade } from "@material-ui/core/styles";
 
 /**
+ * Content container widths
+ */
+export const CONTENT_MAXWIDTH_LG = 1360; // 1280+
+export const CONTENT_MAXWIDTH_XL = 1600; // 1920+
+
+/**
  * Base theme definitions
  */
 const base = {
@@ -106,19 +112,19 @@ export const serifTypography = {
   textTransform: "none",
 };
 export const titleTypography = {
-  fontFamily: `"Champion Middlewt A", "Champion Middlewt B", sans-serif`,
+  fontFamily: `"Champion Middlewt A", "Champion Middlewt B", "Impact", sans-serif`,
   fontStyle: "normal",
   fontWeight: 400,
   textTransform: "uppercase",
 };
 export const compactTitleTypography = {
-  fontFamily: `"Champion Featherwt A", "Champion Featherwt B", sans-serif`,
+  fontFamily: `"Champion Featherwt A", "Champion Featherwt B", "Oswald", "Impact", sans-serif`,
   fontStyle: "normal",
   fontWeight: 400,
   textTransform: "uppercase",
 };
 export const subtitleTypography = {
-  fontFamily: `"Champion Bantamwt A", "Champion Bantamwt B", sans-serif`,
+  fontFamily: `"Champion Bantamwt A", "Champion Bantamwt B", "Impact", sans-serif`,
   fontStyle: "normal",
   fontWeight: 400,
   textTransform: "uppercase",
@@ -299,10 +305,10 @@ const CovidTheme = () => {
       HypContainer: {
         root: {
           [theme.breakpoints.up("lg")]: {
-            maxWidth: 1360,
+            maxWidth: CONTENT_MAXWIDTH_LG,
           },
           [theme.breakpoints.up("xl")]: {
-            maxWidth: 1600,
+            maxWidth: CONTENT_MAXWIDTH_LG,
           },
         },
       },

--- a/src/gatsby-theme-hypersite/breadcrumb/breadcrumb.js
+++ b/src/gatsby-theme-hypersite/breadcrumb/breadcrumb.js
@@ -1,0 +1,9 @@
+import React from "react";
+import Breadcrumb from "gatsby-theme-hypersite/src/breadcrumb/breadcrumb";
+
+/** Limit breadcrumb to top level */
+const SiteBreadcrumb = (props) => {
+  return <Breadcrumb NavigationProps={{ maxDepth: 0 }} {...props} />;
+};
+
+export default SiteBreadcrumb;

--- a/src/gatsby-theme-hypersite/breadcrumb/index.js
+++ b/src/gatsby-theme-hypersite/breadcrumb/index.js
@@ -1,0 +1,2 @@
+export { default as Breadcrumb } from "./breadcrumb";
+export { useBreadcrumb } from "gatsby-theme-hypersite/src/breadcrumb/use-breadcrumb";

--- a/src/gatsby-theme-hypersite/footer/footer.js
+++ b/src/gatsby-theme-hypersite/footer/footer.js
@@ -93,7 +93,6 @@ const styles = (theme) => ({
 });
 
 const Footer = ({ social, links, copyright, classes, className, ...props }) => {
-  console.log(props);
   const handleScrollUp = React.useCallback(() => {
     window.scrollTo(0, 0);
   }, []);

--- a/src/gatsby-theme-hypersite/header/desktop-navigation.js
+++ b/src/gatsby-theme-hypersite/header/desktop-navigation.js
@@ -100,7 +100,6 @@ const styles = (theme) => ({
       "& $list": {
         display: "block",
         columnCount: cols,
-        maxWidth: 1216,
         marginLeft: theme.spacing(27),
         position: "relative",
         paddingTop: theme.spacing(5),

--- a/src/templates/blog-post.js
+++ b/src/templates/blog-post.js
@@ -5,34 +5,102 @@ import { getImage } from "gatsby-plugin-image";
 import { MDXRenderer } from "gatsby-plugin-mdx";
 import Layout from "gatsby-theme-hypersite/src/layout";
 import { Block } from "@hyperobjekt/material-ui-website";
-import { Link } from "gatsby-theme-material-ui";
 import { GatsbyImage } from "gatsby-plugin-image";
-import LeftArrow from "../common/icons/left-arrow.svg";
-import FbIcon from "../common/icons/fb-icon.svg";
-import TwitterIcon from "@material-ui/icons/Twitter";
-import EmailIcon from "@material-ui/icons/Email";
-import IconButton from "@material-ui/core/IconButton";
-import { makeStyles } from "@material-ui/core";
+import { Box, makeStyles, withStyles } from "@material-ui/core";
 import {
-  compactTitleTypography,
+  CONTENT_MAXWIDTH_LG,
+  CONTENT_MAXWIDTH_XL,
   sansSerifyTypography,
   serifTypography,
   subtitleTypography,
 } from "../gatsby-theme-hypercore/theme";
-import moment from "moment";
-import Content from "../components/Content";
-import { useLocation } from "@reach/router";
+import { BlogHero, BlogSocialLinks, BlogLinkedPost } from "../components/blog";
 
-const maxContentWidth = "600px";
+const maxContentWidth = "37.5rem";
+
+const LinkedBlock = withStyles((theme) => ({
+  root: {
+    [theme.breakpoints.down("xs")]: {
+      paddingBottom: 0,
+    },
+  },
+  container: {
+    background: theme.palette.background.alt3,
+    marginRight: 0,
+    paddingTop: theme.spacing(4),
+    paddingBottom: theme.spacing(4),
+    [theme.breakpoints.up("sm")]: {
+      maxWidth: `calc((100% - 6rem) + ((100vw - (100% - 6rem)) / 2))`,
+    },
+    [theme.breakpoints.up("lg")]: {
+      maxWidth: `calc((${CONTENT_MAXWIDTH_LG} - 6rem) + ((100vw - (${CONTENT_MAXWIDTH_LG} - 6rem)) / 2))`,
+    },
+    [theme.breakpoints.up("xl")]: {
+      maxWidth: `calc((${CONTENT_MAXWIDTH_XL} - 6rem) + ((100vw - (${CONTENT_MAXWIDTH_XL} - 6rem)) / 2))`,
+    },
+  },
+}))(Block);
 
 const useStyles = makeStyles((theme) => ({
-  layout: {
-    "& .content": {
-      maxWidth: "unset !important",
-      padding: "unset !important",
+  body: {
+    paddingTop: theme.spacing(3),
+    paddingBottom: theme.spacing(5),
+    [theme.breakpoints.up("sm")]: {
+      paddingTop: theme.spacing(5),
     },
-    "& header": {
-      // background: theme.palette.background.alt3,
+    [theme.breakpoints.up("md")]: {
+      paddingBottom: theme.spacing(7),
+    },
+    [theme.breakpoints.up("lg")]: {
+      paddingBottom: theme.spacing(10),
+    },
+    background: theme.palette.background.paper,
+  },
+  postContent: {
+    position: "relative",
+    wordWrap: "break-word",
+    margin: "auto",
+    maxWidth: maxContentWidth,
+    // dividers within blog post
+    "& > hr": {
+      margin: theme.spacing(3, 0),
+    },
+    // headings within the blog post
+    "& > h1, & > h2, & > h3, & > h4, & > h5, & > h6": {
+      marginTop: "1em",
+    },
+    // default paragraph styles
+    "& > p": {
+      marginBottom: "1rem",
+    },
+    "& .MuiTypography-paragraph": {
+      [theme.breakpoints.between("sm", "md")]: {
+        fontSize: theme.typography.pxToRem(20),
+        lineHeight: 1.6,
+      },
+    },
+    // image and figure margins
+    "& > p > .gatsby-resp-image-wrapper, & > figure": {
+      [theme.breakpoints.up("md")]: {
+        marginBottom: theme.spacing(4),
+        marginTop: theme.spacing(4),
+        marginLeft: theme.spacing(-4),
+        marginRight: theme.spacing(-4),
+      },
+      [theme.breakpoints.up("lg")]: {
+        marginBottom: theme.spacing(6),
+        marginTop: theme.spacing(6),
+        marginLeft: theme.spacing(-6),
+        marginRight: theme.spacing(-6),
+      },
+    },
+    // image captions
+    "& figcaption": {
+      margin: "auto",
+      marginTop: theme.spacing(2),
+      color: theme.palette.text.secondary,
+      textAlign: "center",
+      maxWidth: "34em",
     },
     // SCORECARD TABLE STYLES
     "& .scorecard-table": {
@@ -51,10 +119,21 @@ const useStyles = makeStyles((theme) => ({
         marginRight: theme.columnSpacing(-0.5),
         width: `calc(100% + ${theme.columnSpacing(1)})`,
       },
+      // links
+      "& .MuiLink-root": {
+        fontWeight: 700,
+        color: theme.palette.secondary.main,
+      },
+      // table body text
+      "& .MuiTypography-body1": {
+        ...sansSerifyTypography,
+        fontSize: theme.typography.pxToRem(14),
+      },
+      "& .MuiTable-root": {
+        position: "relative",
+      },
     },
-    "& .scorecard-table .MuiTable-root": {
-      position: "relative",
-    },
+
     "& .MuiTableCell-head:nth-child(5), & .MuiTableCell-body:nth-child(2)": {
       minWidth: 100,
     },
@@ -86,6 +165,7 @@ const useStyles = makeStyles((theme) => ({
     "& .MuiTableCell-body:first-child": {
       textAlign: "left",
     },
+    // letter grade
     "& .MuiTableCell-body:nth-child(2) span:first-child": {
       fontWeight: 700,
       marginRight: 4,
@@ -100,153 +180,8 @@ const useStyles = makeStyles((theme) => ({
     "& .MuiTableRow-root:nth-child(2) .MuiTableCell-body": {
       borderBottom: `1px solid ${theme.palette.text.primary}`,
     },
+
     // END SCORECARD TABLE STYLES
-  },
-  hero: {
-    background: theme.palette.background.alt3,
-    marginTop: "0 !important", // otherwise color shines through
-    paddingTop: theme.spacing(11),
-    paddingLeft: theme.columnSpacing(1),
-    paddingRight: theme.columnSpacing(1),
-    [theme.breakpoints.up("md")]: {
-      paddingRight: theme.columnSpacing(3),
-    },
-  },
-  date: {
-    fontSize: theme.typography.pxToRem(14),
-  },
-  postTitle: {
-    ...compactTitleTypography,
-    color: theme.palette.text.secondary,
-    lineHeight: 1.05,
-    margin: 0,
-    paddingBottom: theme.spacing(5),
-    fontSize: theme.typography.pxToRem(55),
-    [theme.breakpoints.up("sm")]: {
-      fontSize: theme.typography.pxToRem(70),
-    },
-    [theme.breakpoints.up("md")]: {
-      fontSize: theme.typography.pxToRem(85),
-    },
-  },
-  body: {
-    paddingTop: theme.spacing(3),
-    paddingBottom: theme.spacing(5),
-    [theme.breakpoints.up("sm")]: {
-      paddingTop: theme.spacing(5),
-    },
-    [theme.breakpoints.up("md")]: {
-      paddingBottom: theme.spacing(7),
-    },
-    [theme.breakpoints.up("lg")]: {
-      paddingBottom: theme.spacing(10),
-    },
-    background: theme.palette.background.paper,
-  },
-  crumb: {
-    ...sansSerifyTypography,
-    fontSize: theme.typography.pxToRem(13),
-    color: theme.palette.text.secondary + " !important",
-    textDecoration: "none !important",
-    "& img": {
-      paddingRight: theme.spacing(1),
-    },
-  },
-  social: {
-    display: "flex",
-    position: "absolute",
-    top: "-10px",
-    right: theme.columnSpacing(1),
-    color: theme.palette.text.secondary + " !important",
-    "& a": {
-      color: theme.palette.text.secondary + " !important",
-      fontSize: "0",
-    },
-    "& button": {
-      background: theme.palette.background.alt2 + " !important",
-      padding: "10px",
-      marginRight: theme.spacing(1),
-      [theme.breakpoints.down("xs")]: {
-        marginRight: "0",
-        transform: "scale(0.8)",
-      },
-    },
-    [theme.breakpoints.up("lg")]: {
-      flexDirection: "column",
-      right: "unset",
-      top: theme.spacing(10),
-      "& button": {
-        padding: "12px",
-        marginBottom: theme.spacing(1),
-      },
-    },
-  },
-  crumbWrapper: {
-    display: "block",
-    position: "relative",
-    paddingLeft: theme.columnSpacing(1),
-    paddingBottom: theme.spacing(5),
-    [theme.breakpoints.up("md")]: {
-      paddingBottom: theme.spacing(7),
-    },
-    [theme.breakpoints.up("lg")]: {
-      // paddingBottom: theme.spacing(7),
-    },
-  },
-  content: {
-    wordWrap: "break-word",
-    paddingLeft: theme.columnSpacing(1),
-    paddingRight: theme.columnSpacing(1),
-    marginBottom: theme.spacing(7),
-    marginLeft: "auto",
-    marginRight: "auto",
-
-    [theme.breakpoints.up("sm")]: {
-      paddingLeft: theme.columnSpacing(2),
-      paddingRight: theme.columnSpacing(2),
-    },
-    [theme.breakpoints.up("md")]: {
-      maxWidth: `calc(2 * ${theme.columnSpacing(2)} + ${maxContentWidth})`,
-    },
-    [theme.breakpoints.up("lg")]: {
-      marginBottom: theme.spacing(10),
-    },
-    "& .MuiTypography-paragraph": {
-      [theme.breakpoints.between("sm", "md")]: {
-        fontSize: theme.typography.pxToRem(20),
-        lineHeight: 1.6,
-      },
-    },
-
-    "& .gatsby-resp-image-wrapper": {
-      [theme.breakpoints.up("md")]: {
-        marginBottom: theme.spacing(4),
-        marginTop: theme.spacing(4),
-      },
-      [theme.breakpoints.up("lg")]: {
-        marginBottom: theme.spacing(6),
-        marginTop: theme.spacing(6),
-      },
-    },
-    // image captions
-    "& i": {
-      textAlign: "center",
-      display: "block",
-      position: "relative",
-      fontStyle: "normal",
-      // shift them up the amount that the image is pushing them down (theme.spacing),
-      // then shift down to give some distance from image
-      top: `calc(-${theme.spacing(2)} + 5px)`,
-      [theme.breakpoints.up("md")]: {
-        top: `calc(-${theme.spacing(4)} + 10px)`,
-        padding: theme.spacing(0, 1.5),
-      },
-      [theme.breakpoints.up("lg")]: {
-        top: `calc(-${theme.spacing(6)} + 15px)`,
-        padding: theme.spacing(0, 3),
-      },
-    },
-
     "& .continuousColumn": {
       [theme.breakpoints.up("sm")]: {
         columnCount: 2,
@@ -335,114 +270,22 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-const Hero = ({ author, date, title, image }) => {
-  const postDetails = `${author} • ${moment(date).format("MMMM Do, YYYY")}`;
-  const classes = useStyles();
-
-  return (
-    <div className={classes.hero}>
-      <p className={classes.date}>{postDetails}</p>
-      <h2 className={classes.postTitle}>{title}</h2>
-    </div>
-  );
-};
-
-const SocialIcons = ({ title }) => {
-  const location = useLocation();
-  console.log({ location });
-  const classes = useStyles();
-  const url = "https://uclacovidbehindbars.org" + location.pathname;
-
-  const twitterClick = (e) => {
-    window
-      .open(
-        `https://twitter.com/share?text=${title}&url=${url}`,
-        "_blank",
-        "width=550,height=420"
-      )
-      .focus();
-  };
-
-  const facebookClick = (e) => {
-    window
-      .open(
-        `https://www.facebook.com/sharer/sharer.php?u=${url}`,
-        "_blank",
-        "width=550,height=420"
-      )
-      .focus();
-  };
-
-  return (
-    <div className={classes.social}>
-      <IconButton onClick={twitterClick}>
-        <TwitterIcon />
-      </IconButton>
-      <IconButton onClick={facebookClick}>
-        <img alt="share on Facebook" src={FbIcon} />
-      </IconButton>
-      <IconButton>
-        <a
-          target="_blank"
-          href={`mailto:?subject=${title} - UCLA COVID Behind Bars&body=${url}`}
-          rel="noreferrer"
-        >
-          <EmailIcon />
-        </a>
-      </IconButton>
-    </div>
-  );
-};
-
-const BreadCrumb = (title, path) => {
-  const classes = useStyles();
-  return (
-    <div className={classes.crumbWrapper}>
-      <Link className={classes.crumb} to="/blog">
-        <img alt="" src={LeftArrow} /> Back to blog
-      </Link>
-      {SocialIcons(title, path)}
-    </div>
-  );
-};
-
-const Linked = ({ next, previous }) => {
-  const classes = useStyles();
-  const post = next || previous;
-  if (!post) {
-    return null;
-  }
-  const { title, description, path } = post.frontmatter;
-  const sectionTitle = (next ? "next" : "previous") + " post";
-  return (
-    <div className={classes.linkedSection}>
-      <div className={classes.post}>
-        <h3 className={classes.sectionTitle}>{sectionTitle}</h3>
-        <h4 className={classes.linkedTitle}>{title}</h4>
-        <p className={classes.description}>{description}</p>
-
-        <Link className={classes.readLink} to={"/" + path}>
-          Read more
-        </Link>
-      </div>
-    </div>
-  );
-};
-
 const BlogPostTemplate = (props) => {
   const { mdx, allMdx } = props.data;
-  const { image, title } = mdx.frontmatter;
-  console.log({ image, gatsbyimage: getImage(image) });
+  const { author, date, image, title } = mdx.frontmatter;
   const featuredImage = image && getImage(image);
   const classes = useStyles();
   const postNode = allMdx.edges.find((edge) => edge.node.id === mdx.id);
   const { body, ...mdxProps } = getMdxProps(props);
   return (
     <Layout {...mdxProps} {...props}>
-      <Hero {...mdx.frontmatter} />
-      <div className={classes.body}>
-        <Content className={classes.content}>
-          <SocialIcons title={title} />
+      <BlogHero {...{ author, date, title }} />
+      <Block
+        bgcolor="background.paper"
+        ContainerProps={{ style: { position: "relative" } }}
+      >
+        <BlogSocialLinks title={title} />
+        <Box className={classes.postContent}>
           {featuredImage && (
             <GatsbyImage
               className={classes.featuredImage}
@@ -450,9 +293,11 @@ const BlogPostTemplate = (props) => {
             />
           )}
           <MDXRenderer>{body}</MDXRenderer>
-        </Content>
-        <Linked {...postNode} />
-      </div>
+        </Box>
+      </Block>
+      <LinkedBlock bgcolor="background.paper">
+        <BlogLinkedPost {...postNode} />
+      </LinkedBlock>
     </Layout>
   );
 };


### PR DESCRIPTION
Changes:

- separate blog post components / styles
- update blog post captions to use `<figure>` instead `<i>`, CMS widget to follow
- add `Figure` component and make available to mdx (not used yet, but will use for CMS widget)
- add appropriate fallback system font for champion
- override default breadcrumb so it doesn't include subpages
