### PR TITLE
Feature/time series v2 round2

### DIFF
--- a/content/assets/close-icon.svg
+++ b/content/assets/close-icon.svg
@@ -1,4 +1,5 @@
-<svg width="22" height="21" viewBox="0 0 22 21" fill="none" xmlns="http://www.w3.org/2000/svg">
-<line x1="21.1934" y1="0.193558" x2="1.19342" y2="20.1935" stroke="white" stroke-width="0.54712"/>
-<line x1="20.8065" y1="20.1933" x2="0.806551" y2="0.193382" stroke="white" stroke-width="0.54712"/>
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="12" cy="12" r="12" fill="#DDDDCC"/>
+<rect x="7.64453" y="7" width="13.6742" height="0.911612" transform="rotate(45 7.64453 7)" fill="#555526"/>
+<rect x="7" y="16.6692" width="13.6742" height="0.911612" transform="rotate(-45 7 16.6692)" fill="#555526"/>
 </svg>

--- a/content/en.json
+++ b/content/en.json
@@ -48,5 +48,6 @@
   "nat_map_title": "This map displays COVID cases and related deaths of people incarcerated in prisons and jails across the US. Click on a state to access more data.",
   "state_map_title": "Map of ${stateName} with spikes representing the active metric for each facility.",
   "empty_legend_message": "no data available",
-  "scroll_up": "Back to top"
+  "scroll_up": "Back to top",
+  "time_series_facility_select": "Add state facilities, statewide totals, BOP (Federal Bureau of Prisons), or U.S. Immigrations and Customs Enforcement (ICE) facilities to compare trends."
 }

--- a/scripts/loadTimeSeriesData.js
+++ b/scripts/loadTimeSeriesData.js
@@ -55,21 +55,34 @@ async function loadTimeSeries() {
         const newRateKey = newKey + "_rate";
         facility[newRateKey] = "";
 
+        let nullValues = "";
+        let nullRateValues = "";
+
         facRows.forEach((row) => {
           const date = row["Date"];
           const value = getInt(row[accessor]);
+          const valueString = date + "|" + value + ";";
 
-          // record non-values only if some value is already recorded
-          // (so gaps between data are shown, but not large leading gaps)
-          if (Number.isInteger(value) || facility[newKey]) {
-            facility[newKey] += date + "|" + value + ";";
-
-            // ignore populations of 0
-            const population = getInt(row[popAccessor]) || NaN;
+          // ignore populations of 0
+          const population = getInt(row[popAccessor]) || NaN;
+          
+          if (Number.isInteger(value)) {
+            facility[newKey] += nullValues + valueString;
+            nullValues = "";
 
             if (Number.isInteger(population) || facility[newRateKey]) {
               const rate = value / population;
-              facility[newRateKey] += date + "|" + rate + ";";
+              facility[newRateKey] += nullRateValues + date + "|" + rate + ";";
+              nullRateValues = "";
+            }
+          } else if (facility[newKey]) {
+            // record non-values only if some value is already recorded and others are coming
+            // (so gaps between data are shown, but not large leading/trailing gaps)
+            nullValues += valueString;
+
+            if (Number.isInteger(population) || facility[newRateKey]) {
+              const rate = value / population;
+              nullRateValues += date + "|" + rate + ";";
             }
           }
         });

--- a/src/common/constants.js
+++ b/src/common/constants.js
@@ -70,3 +70,20 @@ export const JURISDICTION_GRADIENTS = [
   "url(#g4)",
   "url(#g5)",
 ]
+
+export const TIME_SERIES_COLORS = [
+  "#D7790F",
+  "#82CAA4",
+  "#4C6788",
+  "#84816F",
+  "#71A9C9",
+  "#AE91A8",
+  "#DED6DC",
+  "#B4C551",
+  "#7E55D4",
+  "#A21916",
+  "#BC73AE",
+  "#567EBA",
+  "#FFD540",
+  "#CF5833",
+];

--- a/src/common/hooks/use-time-series-data.js
+++ b/src/common/hooks/use-time-series-data.js
@@ -63,8 +63,7 @@ export default function useTimeSeriesData() {
             ...loadedStateDataMap,
             [state]: d,
           };
-          // loadedStateDataMap[state] = d;
-          console.log(`DATA LOADED FOR ${state}`);
+          // console.log(`DATA LOADED FOR ${state}`);
           setLoaded(state, newStateDataMap);
         })
         .catch((err) => {

--- a/src/common/utils/formatters.js
+++ b/src/common/utils/formatters.js
@@ -1,21 +1,25 @@
-import { METRIC_FORMATTERS } from "../constants"
+import { METRIC_FORMATTERS, TIME_SERIES_COLORS } from "../constants";
 
 export const formatMetricValue = (value, metric) => {
-  const format = METRIC_FORMATTERS[metric] || ((d) => d)
+  const format = METRIC_FORMATTERS[metric] || ((d) => d);
   if (typeof value !== "number" || !Number.isFinite(value)) {
     // fixes #55
-    return "N/A"
-  } else if (metric.includes("_rate") && (value < .01) && (value > 0)) {
-    return "<1%"
-  } else if (metric === "rate_legend" && (value < .01) && (value > 0)) {
-    return METRIC_FORMATTERS.rate_legend_small(value)
-  } else if (metric.includes("_rate") && (value > 1)) {
-    return ">100%"
+    return "N/A";
+  } else if (metric.includes("_rate") && value < 0.01 && value > 0) {
+    return "<1%";
+  } else if (metric === "rate_legend" && value < 0.01 && value > 0) {
+    return METRIC_FORMATTERS.rate_legend_small(value);
+  } else if (metric.includes("_rate") && value > 1) {
+    return ">100%";
   }
-  return format(value)
-}
+  return format(value);
+};
 
 export const formatFacilityName = ({ name, state }) => {
   const appendState = !name.includes(state) && state !== "*other";
   return !appendState ? name : `${name}, ${state}`;
+};
+
+export const getFacilityColor = (index) => {
+  return TIME_SERIES_COLORS[index % TIME_SERIES_COLORS.length];
 };

--- a/src/components/FacilitiesTimeSeries/components/FacilitySelect.js
+++ b/src/components/FacilitiesTimeSeries/components/FacilitySelect.js
@@ -10,6 +10,7 @@ import {
   makeStyles,
   TextField,
   Chip,
+  Icon,
 } from "@material-ui/core";
 // import useFacilitiesMetadata from "../../../common/hooks/use-facilities-metadata";
 import { csv } from "d3-fetch";
@@ -19,11 +20,16 @@ import {
   getFacilityColor,
 } from "../../../common/utils/formatters";
 import { FiberManualRecord } from "@material-ui/icons";
+import CloseIcon from "../../../../content/assets/close-icon.svg";
 
 const useStyles = makeStyles((theme) => ({
   root: {},
   placeholder: {
     display: "none",
+  },
+  chip: {
+    background: "none",
+    border: "1px solid #DDDDCC",
   },
 }));
 
@@ -71,6 +77,7 @@ const FacilitySelect = ({ defaultFacilities = [] }) => {
           renderTags={(tagValue, getTagProps) =>
             tagValue.map((option, i) => (
               <Chip
+                classes={{ root: classes.chip }}
                 icon={
                   <FiberManualRecord style={{ fill: getFacilityColor(i) }} />
                 }
@@ -106,6 +113,11 @@ const FacilitySelect = ({ defaultFacilities = [] }) => {
             renderTags={(tagValue, getTagProps) =>
               tagValue.map((option, i) => (
                 <Chip
+                  deleteIcon={<img src={CloseIcon} alt="remove" />}
+                  classes={{
+                    deleteIcon: classes.deleteIcon,
+                    root: classes.chip,
+                  }}
                   icon={
                     <FiberManualRecord style={{ fill: getFacilityColor(i) }} />
                   }

--- a/src/components/FacilitiesTimeSeries/components/FacilitySelect.js
+++ b/src/components/FacilitiesTimeSeries/components/FacilitySelect.js
@@ -27,6 +27,7 @@ const useStyles = makeStyles((theme) => ({
   root: {},
   placeholder: {
     "& $chip": {
+      display: "inline-flex",
       marginRight: theme.spacing(0.5),
       marginBottom: theme.spacing(0.5),
     },
@@ -82,7 +83,7 @@ const FacilitySelect = ({ defaultFacilities = [] }) => {
               classes={{ root: classes.chip }}
               component="li"
               icon={<FiberManualRecord style={{ fill: getFacilityColor(i) }} />}
-              key={facility.name}
+              key={formatFacilityName(facility)}
               label={formatFacilityName(facility)}
               onDelete={null}
             />

--- a/src/components/FacilitiesTimeSeries/components/FacilitySelect.js
+++ b/src/components/FacilitiesTimeSeries/components/FacilitySelect.js
@@ -10,7 +10,8 @@ import {
   makeStyles,
   TextField,
   Chip,
-  Icon,
+  Box,
+  Typography,
 } from "@material-ui/core";
 // import useFacilitiesMetadata from "../../../common/hooks/use-facilities-metadata";
 import { csv } from "d3-fetch";
@@ -19,13 +20,20 @@ import {
   formatFacilityName,
   getFacilityColor,
 } from "../../../common/utils/formatters";
-import { FiberManualRecord } from "@material-ui/icons";
+import { KeyboardArrowDown, FiberManualRecord } from "@material-ui/icons";
 import CloseIcon from "../../../../content/assets/close-icon.svg";
 
 const useStyles = makeStyles((theme) => ({
   root: {},
   placeholder: {
-    display: "none",
+    "& $chip": {
+      marginRight: theme.spacing(0.5),
+      marginBottom: theme.spacing(0.5),
+    },
+    "& li": {
+      display: "inline-block",
+      listStyle: "none",
+    },
   },
   chip: {
     background: "none",
@@ -61,44 +69,52 @@ const FacilitySelect = ({ defaultFacilities = [] }) => {
 
   return (
     <div className={classes.root}>
-      <div onClick={openHandler}>
-        <Autocomplete
-          multiple
-          open={false}
-          value={selectedFacilities}
-          id="facility-autocomplete-placeholder"
-          options={allFacilities}
-          getOptionLabel={formatFacilityName}
-          renderOption={(option) => option.name}
-          limitTags={4}
-          disableClearable
-          size="small"
-          classes={{ input: classes.placeholder }}
-          renderTags={(tagValue, getTagProps) =>
-            tagValue.map((option, i) => (
-              <Chip
-                classes={{ root: classes.chip }}
-                icon={
-                  <FiberManualRecord style={{ fill: getFacilityColor(i) }} />
-                }
-                label={formatFacilityName(option)}
-                {...getTagProps({ i })}
-                onDelete={null}
-              />
-            ))
-          }
-          renderInput={(params) => (
-            <TextField
-              {...params}
-              variant="standard"
-              label="Facilities"
-              placeholder=""
+      <Box
+        // onClick={openHandler}
+        className={classes.placeholder}
+        position="relative"
+        display="flex"
+        pr={6}
+      >
+        <Box pl={2} component="ul">
+          {selectedFacilities.slice(0, 4).map((facility, i) => (
+            <Chip
+              classes={{ root: classes.chip }}
+              component="li"
+              icon={<FiberManualRecord style={{ fill: getFacilityColor(i) }} />}
+              key={facility.name}
+              label={formatFacilityName(facility)}
+              onDelete={null}
             />
+          ))}
+          {selectedFacilities.length > 4 && (
+            <li>
+              <Typography variant="body">
+                +{selectedFacilities.length - 4}
+              </Typography>
+            </li>
           )}
-        />
-      </div>
-      <Dialog open={modalOpen} onClose={closeHandler}>
-        <DialogTitle>{getLang("time_series_facility_select")}</DialogTitle>
+        </Box>
+        <Box
+          clone
+          position="absolute"
+          width="100%"
+          height="100%"
+          justifyContent="flex-end"
+        >
+          <Button onClick={openHandler}>
+            <KeyboardArrowDown aria-label="edit facilities" />
+          </Button>
+        </Box>
+      </Box>
+      <Dialog
+        aria-labelledby="dialog-title"
+        open={modalOpen}
+        onClose={closeHandler}
+      >
+        <DialogTitle id="dialog-title">
+          {getLang("time_series_facility_select")}
+        </DialogTitle>
         <DialogContent>
           <Autocomplete
             multiple

--- a/src/components/FacilitiesTimeSeries/components/FacilitySelect.js
+++ b/src/components/FacilitiesTimeSeries/components/FacilitySelect.js
@@ -14,26 +14,11 @@ import {
 // import useFacilitiesMetadata from "../../../common/hooks/use-facilities-metadata";
 import { csv } from "d3-fetch";
 import useTimeSeriesStore from "../useTimeSeriesStore";
-import { formatFacilityName } from "../../../common/utils/formatters";
+import {
+  formatFacilityName,
+  getFacilityColor,
+} from "../../../common/utils/formatters";
 import { FiberManualRecord } from "@material-ui/icons";
-
-const colors = [
-  "#D7790F",
-  "#82CAA4",
-  "#4C6788",
-  "#84816F",
-  "#71A9C9",
-  "#AE91A8",
-  "#DED6DC",
-  "#B4C551",
-  "#7E55D4",
-  "#A21916",
-  "#BC73AE",
-  "#567EBA",
-  "#FFD540",
-  "#CF5833",
-];
-
 
 const useStyles = makeStyles((theme) => ({
   root: {},
@@ -65,10 +50,7 @@ const FacilitySelect = ({ defaultFacilities = [] }) => {
     fetchData();
   }, []);
 
-  const openHandler = (e) => {
-    console.log(e);
-    setModalOpen(true);
-  };
+  const openHandler = () => setModalOpen(true);
   const closeHandler = () => setModalOpen(false);
 
   return (
@@ -83,15 +65,14 @@ const FacilitySelect = ({ defaultFacilities = [] }) => {
           getOptionLabel={formatFacilityName}
           renderOption={(option) => option.name}
           limitTags={4}
+          disableClearable
           size="small"
           classes={{ input: classes.placeholder }}
           renderTags={(tagValue, getTagProps) =>
             tagValue.map((option, i) => (
               <Chip
                 icon={
-                  <FiberManualRecord
-                    style={{ fill: colors[i % colors.length] }}
-                  />
+                  <FiberManualRecord style={{ fill: getFacilityColor(i) }} />
                 }
                 label={formatFacilityName(option)}
                 {...getTagProps({ i })}
@@ -126,9 +107,7 @@ const FacilitySelect = ({ defaultFacilities = [] }) => {
               tagValue.map((option, i) => (
                 <Chip
                   icon={
-                    <FiberManualRecord
-                      style={{ fill: colors[i % colors.length] }}
-                    />
+                    <FiberManualRecord style={{ fill: getFacilityColor(i) }} />
                   }
                   label={formatFacilityName(option)}
                   {...getTagProps({ i })}

--- a/src/components/FacilitiesTimeSeries/components/FacilitySelect.js
+++ b/src/components/FacilitiesTimeSeries/components/FacilitySelect.js
@@ -9,11 +9,31 @@ import {
   DialogContent,
   makeStyles,
   TextField,
+  Chip,
 } from "@material-ui/core";
 // import useFacilitiesMetadata from "../../../common/hooks/use-facilities-metadata";
 import { csv } from "d3-fetch";
 import useTimeSeriesStore from "../useTimeSeriesStore";
 import { formatFacilityName } from "../../../common/utils/formatters";
+import { FiberManualRecord } from "@material-ui/icons";
+
+const colors = [
+  "#D7790F",
+  "#82CAA4",
+  "#4C6788",
+  "#84816F",
+  "#71A9C9",
+  "#AE91A8",
+  "#DED6DC",
+  "#B4C551",
+  "#7E55D4",
+  "#A21916",
+  "#BC73AE",
+  "#567EBA",
+  "#FFD540",
+  "#CF5833",
+];
+
 
 const useStyles = makeStyles((theme) => ({
   root: {},
@@ -45,7 +65,10 @@ const FacilitySelect = ({ defaultFacilities = [] }) => {
     fetchData();
   }, []);
 
-  const openHandler = () => setModalOpen(true);
+  const openHandler = (e) => {
+    console.log(e);
+    setModalOpen(true);
+  };
   const closeHandler = () => setModalOpen(false);
 
   return (
@@ -59,12 +82,26 @@ const FacilitySelect = ({ defaultFacilities = [] }) => {
           options={allFacilities}
           getOptionLabel={formatFacilityName}
           renderOption={(option) => option.name}
+          limitTags={4}
           size="small"
           classes={{ input: classes.placeholder }}
+          renderTags={(tagValue, getTagProps) =>
+            tagValue.map((option, i) => (
+              <Chip
+                icon={
+                  <FiberManualRecord
+                    style={{ fill: colors[i % colors.length] }}
+                  />
+                }
+                label={formatFacilityName(option)}
+                {...getTagProps({ i })}
+                onDelete={null}
+              />
+            ))
+          }
           renderInput={(params) => (
             <TextField
               {...params}
-              disabled={true}
               variant="standard"
               label="Facilities"
               placeholder=""
@@ -85,6 +122,19 @@ const FacilitySelect = ({ defaultFacilities = [] }) => {
             renderOption={(option) => option.name}
             groupBy={({ state }) => (state === "*other" ? "" : state)}
             // size="small"
+            renderTags={(tagValue, getTagProps) =>
+              tagValue.map((option, i) => (
+                <Chip
+                  icon={
+                    <FiberManualRecord
+                      style={{ fill: colors[i % colors.length] }}
+                    />
+                  }
+                  label={formatFacilityName(option)}
+                  {...getTagProps({ i })}
+                />
+              ))
+            }
             renderInput={(params) => (
               <TextField
                 {...params}

--- a/src/components/FacilitiesTimeSeries/components/TimeSeriesChart.js
+++ b/src/components/FacilitiesTimeSeries/components/TimeSeriesChart.js
@@ -79,7 +79,7 @@ const TimeSeriesChart = () => {
   return (
     <XYChart
       height={400}
-      margin={{ top: 20, right: 150, bottom: 20, left: 0 }}
+      margin={{ top: 55, right: 150, bottom: 55, left: 55 }}
       xScale={{ type: "time" }}
       yScale={{ type: "linear" }}
       theme={customTheme}
@@ -101,11 +101,23 @@ const TimeSeriesChart = () => {
               <AnnotationLabel
                 title={name}
                 showAnchorLine={false}
-                backgroundFill="rgba(0,150,150,0)"
+                backgroundFill="#F9FCF8"
+                // titleProps={{ paddingLeft: "35px" }}
+                // fontColor={"#283224"}
                 horizontalAnchor="start"
                 verticalAnchor="middle"
                 width={150}
               />
+              {/* <AnnotationLabel
+                title={"⬤"}
+                titleProps={{ color: getFacilityColor(i) }}
+                showAnchorLine={false}
+                backgroundFill="#F9FCF8"
+                fontColor={getFacilityColor(i)}
+                horizontalAnchor="middle"
+                verticalAnchor="middle"
+                // width={10}
+              /> */}
             </Annotation>
           )
       )}

--- a/src/components/FacilitiesTimeSeries/components/TimeSeriesChart.js
+++ b/src/components/FacilitiesTimeSeries/components/TimeSeriesChart.js
@@ -4,7 +4,7 @@ import {
   formatFacilityName,
   getFacilityColor,
 } from "../../../common/utils/formatters";
-
+import moment from "moment";
 import {
   AnimatedAxis,
   Grid,
@@ -51,6 +51,25 @@ const TimeSeriesChart = () => {
     return !linesData.find((lineData) => lineData.id === id);
   });
 
+  const formatDate = (date, i, allTicks) => {
+    const justMonth = "MMM";
+    const monthAndYear = "MMM 'YY";
+
+    const d = moment(date);
+    // first date
+    if (!i) {
+      const lastD = moment(allTicks[allTicks.length - 1].value);
+      // show year only if the data doesn't span multiple
+      const format = d.year() !== lastD.year() ? justMonth : monthAndYear;
+      return d.format(format);
+    } else {
+      const previousD = moment(allTicks[i - 1].value);
+      // show year only if this tick is in the next year
+      const format = d.year() === previousD.year() ? justMonth : monthAndYear;
+      return d.format(format);
+    }
+  };
+
   console.log("loading:", dataLoading);
   return (
     <XYChart
@@ -59,16 +78,16 @@ const TimeSeriesChart = () => {
       yScale={{ type: "linear" }}
       theme={customTheme}
     >
-      <AnimatedAxis orientation="bottom" />
+      <AnimatedAxis tickFormat={formatDate} orientation="bottom" />
       <AnimatedAxis
         orientation="left"
         numTicks={4}
         // tickLabelProps={() => ({ dx: -10 })}
       />
-      {/* <Grid
-      // columns={true}
-      // numTicks={4}
-      /> */}
+      <Grid
+        columns={false}
+        numTicks={4}
+      />
       {linesData.map(({ name, lineData }, i) => (
         <AnimatedLineSeries
           key={name}
@@ -96,6 +115,6 @@ const TimeSeriesChart = () => {
       />
     </XYChart>
   );
-};
+};;;;
 
 export default TimeSeriesChart;

--- a/src/components/FacilitiesTimeSeries/components/TimeSeriesChart.js
+++ b/src/components/FacilitiesTimeSeries/components/TimeSeriesChart.js
@@ -6,11 +6,13 @@ import {
 } from "../../../common/utils/formatters";
 import moment from "moment";
 import {
-  AnimatedAxis,
+  Axis,
   Grid,
-  AnimatedLineSeries,
+  LineSeries,
   XYChart,
   Tooltip,
+  Annotation,
+  AnnotationLabel,
   buildChartTheme,
 } from "@visx/xychart";
 import useTimeSeriesStore from "../useTimeSeriesStore";
@@ -40,8 +42,11 @@ const TimeSeriesChart = () => {
     const lineData = facilityData[accessor];
     const { id } = facilitiesData;
     const name = formatFacilityName(facilityData);
-
-    return { name, id, lineData };
+    const lastDatum = lineData.reduceRight((accum, datum) => {
+      if (accum) return accum;;
+      if (!!datum.value) return datum;;
+    }, null);
+    return { name, id, lineData, lastDatum };
   });
 
   const colors = linesData.map((l, i) => getFacilityColor(i));
@@ -74,28 +79,36 @@ const TimeSeriesChart = () => {
   return (
     <XYChart
       height={400}
+      margin={{ top: 20, right: 150, bottom: 20, left: 0 }}
       xScale={{ type: "time" }}
       yScale={{ type: "linear" }}
       theme={customTheme}
     >
-      <AnimatedAxis tickFormat={formatDate} orientation="bottom" />
-      <AnimatedAxis
+      <Axis tickFormat={formatDate} orientation="bottom" />
+      <Axis
         orientation="left"
         numTicks={4}
         // tickLabelProps={() => ({ dx: -10 })}
       />
-      <Grid
-        columns={false}
-        numTicks={4}
-      />
+      <Grid columns={false} numTicks={4} />
       {linesData.map(({ name, lineData }, i) => (
-        <AnimatedLineSeries
-          key={name}
-          dataKey={name}
-          data={lineData}
-          {...accessors}
-        />
+        <LineSeries key={name} dataKey={name} data={lineData} {...accessors} />
       ))}
+      {linesData.map(
+        ({ name, lastDatum }, i) =>
+          lastDatum && (
+            <Annotation dataKey={name} datum={lastDatum} dx={0} dy={0}>
+              <AnnotationLabel
+                title={name}
+                showAnchorLine={false}
+                backgroundFill="rgba(0,150,150,0)"
+                horizontalAnchor="start"
+                verticalAnchor="middle"
+                width={150}
+              />
+            </Annotation>
+          )
+      )}
       <Tooltip
         snapTooltipToDatumX
         snapTooltipToDatumY
@@ -115,6 +128,6 @@ const TimeSeriesChart = () => {
       />
     </XYChart>
   );
-};;;;
+};
 
 export default TimeSeriesChart;

--- a/src/components/FacilitiesTimeSeries/components/TimeSeriesChart.js
+++ b/src/components/FacilitiesTimeSeries/components/TimeSeriesChart.js
@@ -3,7 +3,7 @@ import useTimeSeriesData from "../../../common/hooks/use-time-series-data";
 import { formatFacilityName } from "../../../common/utils/formatters";
 
 import {
-  AnimatedAxis, // any of these can be non- equivalents
+  AnimatedAxis,
   Grid,
   AnimatedLineSeries,
   XYChart,
@@ -11,6 +11,23 @@ import {
 } from "@visx/xychart";
 import useTimeSeriesStore from "../useTimeSeriesStore";
 import shallow from "zustand/shallow";
+
+const colors = [
+  "#D7790F",
+  "#82CAA4",
+  "#4C6788",
+  "#84816F",
+  "#71A9C9",
+  "#AE91A8",
+  "#DED6DC",
+  "#B4C551",
+  "#7E55D4",
+  "#A21916",
+  "#BC73AE",
+  "#567EBA",
+  "#FFD540",
+  "#CF5833",
+];
 
 const accessors = {
   xAccessor: (d) => new Date(`${d.date}T00:00:00`),
@@ -58,11 +75,12 @@ const TimeSeriesChart = () => {
       // columns={true}
       // numTicks={4}
       /> */}
-      {linesData.map(({ name, lineData }) => (
+      {linesData.map(({ name, lineData }, i) => (
         <AnimatedLineSeries
           key={name}
           dataKey={name}
           data={lineData}
+          stroke={colors[i % colors.length]}
           {...accessors}
         />
       ))}

--- a/src/components/FacilitiesTimeSeries/components/TimeSeriesChart.js
+++ b/src/components/FacilitiesTimeSeries/components/TimeSeriesChart.js
@@ -1,6 +1,9 @@
 import React from "react";
 import useTimeSeriesData from "../../../common/hooks/use-time-series-data";
-import { formatFacilityName } from "../../../common/utils/formatters";
+import {
+  formatFacilityName,
+  getFacilityColor,
+} from "../../../common/utils/formatters";
 
 import {
   AnimatedAxis,
@@ -8,26 +11,10 @@ import {
   AnimatedLineSeries,
   XYChart,
   Tooltip,
+  buildChartTheme,
 } from "@visx/xychart";
 import useTimeSeriesStore from "../useTimeSeriesStore";
 import shallow from "zustand/shallow";
-
-const colors = [
-  "#D7790F",
-  "#82CAA4",
-  "#4C6788",
-  "#84816F",
-  "#71A9C9",
-  "#AE91A8",
-  "#DED6DC",
-  "#B4C551",
-  "#7E55D4",
-  "#A21916",
-  "#BC73AE",
-  "#567EBA",
-  "#FFD540",
-  "#CF5833",
-];
 
 const accessors = {
   xAccessor: (d) => new Date(`${d.date}T00:00:00`),
@@ -51,20 +38,27 @@ const TimeSeriesChart = () => {
 
   const linesData = facilitiesData.map((facilityData) => {
     const lineData = facilityData[accessor];
-    const { id } = facilitiesData
+    const { id } = facilitiesData;
     const name = formatFacilityName(facilityData);
-    
-    return ({ name, id, lineData });
+
+    return { name, id, lineData };
   });
 
+  const colors = linesData.map((l, i) => getFacilityColor(i));
+  const customTheme = buildChartTheme({ colors });
+
   const dataLoading = selectedFacilities.some(({ id }) => {
-    return !linesData.find(lineData => lineData.id === id)
+    return !linesData.find((lineData) => lineData.id === id);
   });
-  
+
   console.log("loading:", dataLoading);
-  console.log("#::", linesData);
   return (
-    <XYChart height={400} xScale={{ type: "time" }} yScale={{ type: "linear" }}>
+    <XYChart
+      height={400}
+      xScale={{ type: "time" }}
+      yScale={{ type: "linear" }}
+      theme={customTheme}
+    >
       <AnimatedAxis orientation="bottom" />
       <AnimatedAxis
         orientation="left"
@@ -80,7 +74,6 @@ const TimeSeriesChart = () => {
           key={name}
           dataKey={name}
           data={lineData}
-          stroke={colors[i % colors.length]}
           {...accessors}
         />
       ))}

--- a/src/gatsby-theme-hypercore/theme.js
+++ b/src/gatsby-theme-hypercore/theme.js
@@ -130,8 +130,6 @@ export const subtitleTypography = {
   textTransform: "uppercase",
 };
 
-export const MAX_CONTENT_WIDTH = 1400;
-
 /**
  * A function that accepts site context (currently only `isDarkMode`)
  * and returns a theme object that is applied to the site.


### PR DESCRIPTION
Follow up to #378 with implementation of a handful of UI/UX items, to conform to [designs](https://www.figma.com/file/TKdSksUXJjYDl9FePrEiZz/UCLA---CBB---Style-guide%2C-Site-map?node-id=1611%3A0), including:
- Facility Select
  - convert to modal interface
  - style the "chips" with a color tag
- sample axis tick date formatting 
- color plot lines to match chips
- add grid lines to chart

Deployed [here](https://deploy-preview-390--covid-19-behind-bars.netlify.app/)

Still to do (pending design confirmation):
- style entire "sentence" of metric/population/facility selection elements
- polish styling of facility select Autocompletes
- chart legend. I'm not sure there will be a straightforward way of implementing this as designed based on [this](https://github.com/airbnb/visx/discussions/1143) - if the legend is a separate HTML element than the SVG chart, lining up the facility names with the corresponding line seems tricky. Also, some facility names are quite long, so we'd potentially be eating into a lot of the chart real estate on smaller screens by having the legend off to the right. Maybe the names could be added instead as some kind of line label (or ["annotation"](https://airbnb.io/visx/docs/annotation)), but again with long names (and lines that often overlap) this could be tricky. If we find an acceptable design for it, the simplest route might be to adapt the facility select element to serve as the legend (since it has all the names/colors anyways).